### PR TITLE
Make compare tabs equally wide

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@ Upcoming
 - Increase width of name/path textfields when editing a report
 - Fix checkpoint showing wrong truncate message
 - Make checkpoint truncating happen while generating the report, instead of afterwards
+- Make compare tabs equally wide
 
 
 

--- a/src/main/java/nl/nn/testtool/echo2/ComparePane.java
+++ b/src/main/java/nl/nn/testtool/echo2/ComparePane.java
@@ -148,7 +148,8 @@ public class ComparePane extends Tab implements BeanParent {
 		splitPane1.setResizable(true);
 		// TODO: Change separator position to 50% of browser's screen width for compatibility
 		// with values other than the most common full-sized browser window width of 1920px;
-		// using "new Extent(50, Extent.PERCENT)" is 'unsupported for this context'.
+		// using "new Extent(50, Extent.PERCENT)" returns an exception saying the
+		// 'Extent.PERCENT' unit is 'unsupported for this context'.
 		splitPane1.setSeparatorPosition(new Extent(960, Extent.PX));
 
 		SplitPane splitPane2 = new SplitPane(SplitPane.ORIENTATION_VERTICAL);

--- a/src/main/java/nl/nn/testtool/echo2/ComparePane.java
+++ b/src/main/java/nl/nn/testtool/echo2/ComparePane.java
@@ -143,10 +143,13 @@ public class ComparePane extends Tab implements BeanParent {
 		reportComponent2 = new ReportComponent();
 		PathComponent pathComponent2 = new PathComponent();
 		checkpointComponent2 = new CheckpointComponent();
-
+		
 		SplitPane splitPane1 = new SplitPane(SplitPane.ORIENTATION_HORIZONTAL);
 		splitPane1.setResizable(true);
-		splitPane1.setSeparatorPosition(new Extent(600, Extent.PX));
+		// TODO: Change separator position to 50% of browser's screen width for compatibility
+		// with values other than the most common full-sized browser window width of 1920px;
+		// using "new Extent(50, Extent.PERCENT)" is 'unsupported for this context'.
+		splitPane1.setSeparatorPosition(new Extent(960, Extent.PX));
 
 		SplitPane splitPane2 = new SplitPane(SplitPane.ORIENTATION_VERTICAL);
 		splitPane2.setResizable(true);


### PR DESCRIPTION
Since Echo2 doesn't support getting the browser screen width, the new position has been set to 960, 50% of the most commonly occurring screen width of 1920px.