### PR TITLE
Move truncate functionality

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@ Upcoming
 
 - Increase width of name/path textfields when editing a report
 - Fix checkpoint showing wrong truncate message
+- Make checkpoint truncating happen while generating the report, instead of afterwards
 
 
 

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -219,6 +219,12 @@ public class Checkpoint implements Serializable, Cloneable {
 		return name;
 	}
 
+	/**
+	 * Sets the length of the message before it was truncated, so that the Ladybug's UI
+	 * can display the amount of characters that were removed from the original message.
+	 * 
+	 * @param length The length of the message before it was truncated.
+	 */
 	public void setPreTruncatedMessageLength(int length) {
 		preTruncatedMessageLength = length;
 	}

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -40,6 +40,7 @@ public class Checkpoint implements Serializable, Cloneable {
 	private boolean messageHasBeenStubbed = false;
 	private int stub = STUB_FOLLOW_REPORT_STRATEGY;
 	private int preTruncatedMessageLength = -1;
+	private long estimatedMemoryUsage = -1;
 
 	public transient static final int TYPE_NONE = 0;
 	public transient static final int TYPE_STARTPOINT = 1;
@@ -199,7 +200,9 @@ public class Checkpoint implements Serializable, Cloneable {
 	 * @return estimated memory usage in bytes
 	 */
 	public long getEstimatedMemoryUsage() {
-		if (message == null) {
+		if (estimatedMemoryUsage > -1) {
+			return estimatedMemoryUsage;
+		} else if (message == null) {
 			return 0L;
 		} else {
 			return message.length() * 2;
@@ -222,5 +225,9 @@ public class Checkpoint implements Serializable, Cloneable {
 
 	public int getPreTruncatedMessageLength() {
 		return preTruncatedMessageLength;
+	}
+	
+	public void setEstimatedMemoryUsage(long estimatedMemoryUsage) {
+		this.estimatedMemoryUsage = estimatedMemoryUsage;
 	}
 }

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -321,6 +321,7 @@ public class Report implements Serializable {
 		// For a message that is referenced by multiple checkpoints, have one truncated message that is
 		// referenced by those checkpoints, to prevent creating multiple String objects representing the
 		// same string and occupying unnecessary memory.
+		checkpoint.setPreTruncatedMessageLength(message.length());
 		if(truncatedMessageMap.containsKey(message)) {
 			checkpoint.setEstimatedMemoryUsage(0L);
 			return truncatedMessageMap.get(message);
@@ -330,7 +331,6 @@ public class Report implements Serializable {
 			
 			truncatedMessageMap.put(message, truncatedMessage);
 			checkpoint.setEstimatedMemoryUsage(2 * truncatedMessage.length());
-			checkpoint.setPreTruncatedMessageLength(message.length());
 			return truncatedMessage;
 		}
 	}

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -268,7 +268,7 @@ public class Report implements Serializable {
 	}
 
 	private Object addCheckpoint(String threadName, String sourceClassName, String name, Object message, int checkpointType, Integer index, Integer level, int levelChangeNextCheckpoint) {
-		if (checkpoints.size() < testTool.getMaxCheckpoints() || getEstimatedMemoryUsage() < 100000000L) {
+		if (checkpoints.size() < testTool.getMaxCheckpoints()) {
 			Checkpoint checkpoint = new Checkpoint(this, threadName, sourceClassName, name, message, checkpointType, level.intValue());
 			checkpoints.add(index.intValue(), checkpoint);
 			if (originalReport != null) {

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -169,11 +169,7 @@ public class TestTool {
 					message = report.checkpoint(threadId, sourceClassName, name, message, checkpointType, levelChangeNextCheckpoint);
 					reportsInProgressEstimatedMemoryUsage = reportsInProgressEstimatedMemoryUsage + report.getEstimatedMemoryUsage();
 					if (report.finished()) {
-						report.setEndTime(System.currentTimeMillis());
-						if(maxMessageLength > 0) {
-							truncateCheckpointMessages(report);
-						}
-						
+						report.setEndTime(System.currentTimeMillis());						
 						log.debug("Report is finished for '" + correlationId + "'");
 						reportsInProgress.remove(report);
 						reportsInProgressByCorrelationId.remove(correlationId);
@@ -190,29 +186,6 @@ public class TestTool {
 			}
 		}
 		return message;
-	}
-
-	private void truncateCheckpointMessages(Report report) {
-		// For a message that is referenced by multiple checkpoints, have one truncated message that is
-		// referenced by those checkpoints, to prevent creating multiple String objects representing the
-		// same string and occupying unnecessary memory.
-		Map<String, String> truncatedMessages = new RefCompareMap<String, String>();
-		
-		for(Checkpoint cp : report.getCheckpoints()) {
-			if(cp.getMessage() != null) {				
-				if(truncatedMessages.containsKey(cp.getMessage())) {
-					cp.setPreTruncatedMessageLength(cp.getMessage().length());
-					cp.setMessage(truncatedMessages.get(cp.getMessage()));
-				} else if(cp.getMessage().length() > maxMessageLength) {
-					String truncatedMessage = cp.getMessage().substring(0, maxMessageLength)
-						+ "... ("+(cp.getMessage().length() - maxMessageLength)+" more characters)";
-					
-					truncatedMessages.put(cp.getMessage(), truncatedMessage);
-					cp.setPreTruncatedMessageLength(cp.getMessage().length());
-					cp.setMessage(truncatedMessage);
-				}
-			}
-		}
 	}
 	
 	public Object startpoint(String correlationId, String sourceClassName, String name, Object message) {
@@ -419,92 +392,5 @@ public class TestTool {
 
 	public static String getImplementationVersion() {
 		return Package.getPackage("nl.nn.testtool").getImplementationVersion();
-	}
-}
-
-/**
- * A custom implementation of the map interface that compares keys based on their object reference, i.e. comparing with 'o1 == o2' rather than 'o1.equals(o2)'.
- * This greatly enhances the performance of maps with large objects as keys.
- * <p>
- * Note: Since this implementation was written with a specific use case in mind, most methods are not implemented and will throw an exception when called. 
- */
-class RefCompareMap<K, V> implements Map<K, V> {
-	
-	private List<K> keys = new ArrayList<K>();
-	private List<V> values = new ArrayList<V>();
-	
-	@Override
-	public V get(Object key) {
-		int i = 0;
-		for(Object o : keys) {
-			if(o == key) {
-				return values.get(i);
-			}
-			i++;
-		}
-		return null;
-	}
-	
-	@Override
-	public V put(K key, V value) {
-		keys.add(key);
-		values.add(value);
-		
-		return value;
-	}
-	
-	@Override
-	public boolean containsKey(Object key) {
-		for(Object o : keys) {
-			if(o == key) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	@Override
-	public void clear() {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public boolean containsValue(Object value) {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public Set entrySet() {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public boolean isEmpty() {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public Set keySet() {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public void putAll(Map m) {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public V remove(Object key) {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public int size() {
-		throw new NotImplementedException();
-	}
-
-	@Override
-	public Collection values() {
-		throw new NotImplementedException();
 	}
 }

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -17,13 +17,10 @@ package nl.nn.testtool;
 
 import java.rmi.server.UID;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 


### PR DESCRIPTION
Having messages truncated while reports are being made (rather than all at once afterwards) allows the developer to get an accurate value for getEstimatedMemoryUsage() during the report's initialisation. In this case, for example (link to future pull request pending).