### PR TITLE
Add memory usage limit for adding more checkpoints

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@ Upcoming
 - Increase width of name/path textfields when editing a report
 - Fix checkpoint showing wrong truncate message
 - Make checkpoint truncating happen while generating the report, instead of afterwards
+- Prevent checkpoints from being created when the report occupies too much memory
 - Make compare tabs equally wide
 
 

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -19,7 +19,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -305,7 +306,11 @@ public class Report implements Serializable {
 				log.debug("Added checkpoint " + getCheckpointLogDescription(name, checkpointType, level));
 			}
 		} else {
-			log.warn("Maximum number of checkpoints exceeded, ignored checkpoint " + getCheckpointLogDescription(name, checkpointType, level));
+			if(checkpoints.size() == testTool.getMaxCheckpoints()){
+				log.warn("Maximum number of checkpoints exceeded, ignored checkpoint " + getCheckpointLogDescription(name, checkpointType, level));
+			} else {
+				log.warn("Maximum memory usage reached for this report, ignored checkpoint " + getCheckpointLogDescription(name, checkpointType, level));
+			}
 		}
 		for (int i = threads.indexOf(threadName); i < threads.size(); i++) {
 			Object key = threads.get(i);

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -264,7 +264,7 @@ public class Report implements Serializable {
 	}
 
 	private Object addCheckpoint(String threadName, String sourceClassName, String name, Object message, int checkpointType, Integer index, Integer level, int levelChangeNextCheckpoint) {
-		if (checkpoints.size() < testTool.getMaxCheckpoints()) {
+		if (checkpoints.size() < testTool.getMaxCheckpoints() && getEstimatedMemoryUsage() < testTool.getMaxMemoryUsage()) {
 			Checkpoint checkpoint = new Checkpoint(this, threadName, sourceClassName, name, message, checkpointType, level.intValue());
 			checkpoints.add(index.intValue(), checkpoint);
 			if (originalReport != null) {

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -92,11 +92,6 @@ public class TestTool {
 		this.maxMemoryUsage = maxMemoryUsage;
 	}
 	
-	/**
-	 * 
-	 * @return The value of <code>ibistesttool.maxMemoryUsage</code> as (optionally) specified in a property file.
-	 * If no such property is found, a default value is used.
-	 */
 	public long getMaxMemoryUsage() {
 		return maxMemoryUsage;
 	}

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -44,6 +44,7 @@ public class TestTool {
 	private String configVersion;
 	private int maxCheckpoints = 2500;
 	private int maxMessageLength = -1;
+	private long maxMemoryUsage = 100000000L;
 	private Debugger debugger;
 	private boolean reportGeneratorEnabled = true;
 	private List reportsInProgress = new ArrayList();
@@ -88,6 +89,19 @@ public class TestTool {
 
 	public int getMaxMessageLength() {
 		return maxMessageLength;
+	}
+	
+	public void setMaxMemoryUsage(long maxMemoryUsage) {
+		this.maxMemoryUsage = maxMemoryUsage;
+	}
+	
+	/**
+	 * 
+	 * @return The value of <code>ibistesttool.maxMemoryUsage</code> as (optionally) specified in a property file.
+	 * If no such property is found, a default value is used.
+	 */
+	public long getMaxMemoryUsage() {
+		return maxMemoryUsage;
 	}
 
 	public void setDebugger(Debugger debugger) {


### PR DESCRIPTION
When adding a checkpoint to a report, the report's estimated memory usage up to that point is checked against a maximum (default 100MB).