### PR TITLE
Interactive parametering

### DIFF
--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -22,15 +22,24 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import nl.nn.testtool.run.ReportRunner;
+import nl.nn.testtool.run.RunResult;
 import nl.nn.testtool.storage.Storage;
+import nl.nn.testtool.storage.StorageException;
 import nl.nn.testtool.transform.MessageTransformer;
 import nl.nn.testtool.transform.ReportXmlTransformer;
 import nl.nn.testtool.util.EscapeUtil;
 import nl.nn.testtool.util.LogUtil;
+import nl.nn.testtool.util.XmlUtil;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -273,7 +273,11 @@ public class TestTool {
 			correlationId = getCorrelationId();
 		}
 		if(report.hasInputVariables()) {
-			report.parseInputVariables(reportRunner);
+			if(reportRunner != null) {
+				report.parseInputVariables(reportRunner);
+			} else {
+				log.warn("Input variable parsing does not (currently) work outside of the Test tab's rerun functionality");
+			}
 		}
 		boolean reportGeneratorEnabled = getReportGeneratorEnabled();
 		if (reportGeneratorEnabled) {

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
+import nl.nn.testtool.run.ReportRunner;
 import nl.nn.testtool.storage.LogStorage;
 import nl.nn.testtool.transform.MessageTransformer;
 import nl.nn.testtool.util.LogUtil;
@@ -263,13 +264,16 @@ public class TestTool {
 	}
 
 	public String rerun(Report report, SecurityContext securityContext) {
-		return rerun(null, report, securityContext);
+		return rerun(null, report, securityContext, null);
 	}
 
-	public String rerun(String correlationId, Report report, SecurityContext securityContext) {
+	public String rerun(String correlationId, Report report, SecurityContext securityContext, ReportRunner reportRunner) {
 		String errorMessage = null;
 		if (correlationId == null) {
 			correlationId = getCorrelationId();
+		}
+		if(report.hasInputVariables()) {
+			report.parseInputVariables(reportRunner);
 		}
 		boolean reportGeneratorEnabled = getReportGeneratorEnabled();
 		if (reportGeneratorEnabled) {

--- a/src/main/java/nl/nn/testtool/echo2/ComparePane.java
+++ b/src/main/java/nl/nn/testtool/echo2/ComparePane.java
@@ -253,7 +253,7 @@ public class ComparePane extends Tab implements BeanParent {
 	}
 
 	public void compare(Report report1, Report report2) {
-		if (report1.toXml().equals(report2.toXml())) {
+		if (report1.equalsOther(report2)) {
 			report1.setDifferenceFound(false);
 			report2.setDifferenceFound(false);
 		} else {
@@ -292,7 +292,7 @@ public class ComparePane extends Tab implements BeanParent {
 					if (i < ids2.size()) {
 						Integer id2 = (Integer)ids2.get(i);
 						Report report2 = storage2.getReport(id2);
-						if (report1.toXml().equals(report2.toXml())) {
+						if (report1.equalsOther(report2)) {
 							report1.setDifferenceFound(false);
 							report2.setDifferenceFound(false);
 						} else {

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -409,7 +409,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 						runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
 						runResultReport.setTransformation(report.getTransformation());
 						runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-						if (report.toXml().equals(runResultReport.toXml())) {
+						if (report.equalsOther(runResultReport)) {
 							label.setForeground(Echo2Application.getNoDifferenceFoundTextColor());
 						} else {
 							label.setForeground(Echo2Application.getDifferenceFoundTextColor());

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -190,6 +190,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		buttonRow.add(progressBar);
 		reportRunner = new ReportRunner();
 		reportRunner.setTestTool(testTool);
+		reportRunner.setDebugStorage(debugStorage);
 
 		Row uploadSelectRow = new Row();
 

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -671,7 +671,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private Report getRunResultReport(String runResultCorrelationId) {
 		Report report = null;
 		try {
-			report = ReportRunner.getRunResultReport(debugStorage, runResultCorrelationId);
+			report = reportRunner.getRunResultReport(runResultCorrelationId);
 		} catch(StorageException storageException) {
 			displayAndLogError(storageException);
 		}

--- a/src/main/java/nl/nn/testtool/run/ReportRunner.java
+++ b/src/main/java/nl/nn/testtool/run/ReportRunner.java
@@ -38,9 +38,14 @@ public class ReportRunner implements Runnable {
 	private int maximum = 1;
 	private Map<Integer, RunResult> results = Collections.synchronizedMap(new HashMap<Integer, RunResult>());
 	private boolean running = false;
+	private Storage debugStorage;
 
 	public void setTestTool(TestTool testTool) {
 		this.testTool = testTool;
+	}
+
+	public void setDebugStorage(Storage debugStorage) {
+		this.debugStorage = debugStorage;
 	}
 
 	public void setSecurityContext(SecurityContext securityContext) {
@@ -88,7 +93,8 @@ public class ReportRunner implements Runnable {
 	private void run(Report report) {
 		RunResult runResult = new RunResult();
 		runResult.correlationId = TestTool.getCorrelationId();
- 		runResult.errorMessage = testTool.rerun(runResult.correlationId, report, securityContext);
+ 		runResult.errorMessage = testTool.rerun(runResult.correlationId, report, securityContext, this);
+ 		runResult.fullPath = report.getFullPath();
 		results.put(report.getStorageId(), runResult);
 	}
 
@@ -104,7 +110,7 @@ public class ReportRunner implements Runnable {
 		return results;
 	}
 
-	public static Report getRunResultReport(Storage debugStorage, String runResultCorrelationId)
+	public Report getRunResultReport(String runResultCorrelationId)
 			throws StorageException {
 		Report report = null;
 		List<String> metadataNames = new ArrayList<String>();
@@ -122,5 +128,9 @@ public class ReportRunner implements Runnable {
 			report = debugStorage.getReport(runResultStorageId);
 		}
 		return report;
+	}
+
+	public Storage getDebugStorage() {
+		return debugStorage;
 	}
 }

--- a/src/main/java/nl/nn/testtool/run/RunResult.java
+++ b/src/main/java/nl/nn/testtool/run/RunResult.java
@@ -21,4 +21,5 @@ package nl.nn.testtool.run;
 public class RunResult {
 	public String errorMessage;
 	public String correlationId;
+	public String fullPath;
 }


### PR DESCRIPTION
A new bit of functionality that allows users to refer to a previously run report's run-result for input data. Currently, it is only possible to extract data from valid XML messages. The syntax is as follows:
${report(__relative path to target report__)/checkpoint(__index of target checkpoint__)/xpath(__xpath expression that points to the desired data__)}


Example:

> ${**report(../Pipeline HelloWorld)**/checkpoint(3)/xpath(test/result)}

The user refers to the 'Pipeline HelloWorld' report in the parent folder...

> ${report(./Pipeline ManageDatabase)/**checkpoint(3)**/xpath(test/result)}

...then selects the report's third checkpoint, of which the index can be found in the checkpoint's path...

> ${report(./Pipeline ManageDatabase)/checkpoint(3)/**xpath(test/result)**}

...to then grab the value '1337' of that checkpoint's XML message, which would be "<test><result>1337</result></test>".