### PR TITLE
Add report parameterization

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,23 @@ Ladybug Test Tool release notes
 Upcoming
 --------
 
+
+
+
+2.0.12
+---
+
+- Add functionality to declare and use ${variables} for reports
+- Add functionality to generate clone reports based on a CSV-table of variables
+- Add functionality to refer to data in another report's checkpoints
+- Clarify delete message (delete selected reports? -> delete X selected reports?)
+- Clarify truncate message (X characters remaining -> X characters removed)
+
+
+
+2.0.11
+---
+
 - Increase width of name/path textfields when editing a report
 - Fix checkpoint showing wrong truncate message
 - Make checkpoint truncating happen while generating the report, instead of afterwards

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -56,11 +56,11 @@ public class Checkpoint implements Serializable, Cloneable {
 	private int stub = STUB_FOLLOW_REPORT_STRATEGY;
 	private int preTruncatedMessageLength = -1;
 	private long estimatedMemoryUsage = -1;
-	private transient static Pattern simpleVariableCheckPattern;
+	private transient static Pattern genericVariableCheckPattern;
 	private transient static Pattern externalVariablePattern;
 	private transient Map<String, Pattern> variablePatternMap;
 	static {
-		simpleVariableCheckPattern = Pattern.compile("\\$\\{.*?\\}");
+		genericVariableCheckPattern = Pattern.compile("\\$\\{.*?\\}");
 		externalVariablePattern = Pattern.compile("\\$\\{report\\((.*?)\\)\\/checkpoint\\(([0-9]+)\\)\\/xpath\\((.*?)\\)\\}");
 	}
 
@@ -262,7 +262,7 @@ public class Checkpoint implements Serializable, Cloneable {
 	public String getMessageWithResolvedVariables(ReportRunner reportRunner) {
 		String result = getMessage();
 		if(getMessage() != null && containsVariables()) {
-			// 1. Parse interactive report variables
+			// 1. Parse external report variables
 			if(reportRunner != null) {
 				List<MatchResult> matchResults = new ArrayList<MatchResult>();
 				Matcher m = externalVariablePattern.matcher(getMessage());
@@ -290,7 +290,7 @@ public class Checkpoint implements Serializable, Cloneable {
 						switch(operations[i]) {
 							case -1:
 								if(determinedPath != "/") {
-									determinedPath = determinedPath.substring(0, determinedPath.length()- splitDeterminedPath[splitDeterminedPath.length-1].length()-1);
+									determinedPath = determinedPath.substring(0, determinedPath.length() - splitDeterminedPath[splitDeterminedPath.length-1].length()-1);
 								}
 								break;
 							case 1:
@@ -341,7 +341,7 @@ public class Checkpoint implements Serializable, Cloneable {
 					}
 				}
 			}
-			// 2. Parse dynamic variables
+			// 2. Parse local variables
 			if(StringUtils.isNotEmpty(report.getVariableCsv())) {
 				Map<String, String> variableMap = report.getVariablesAsMap();
 				Map<String, Pattern> variablePatternMap = getVariablePatternMap(variableMap);
@@ -362,7 +362,7 @@ public class Checkpoint implements Serializable, Cloneable {
 	
 	public boolean containsVariables() {
 		if(StringUtils.isEmpty(getMessage())) return false;
-		return simpleVariableCheckPattern.matcher(getMessage()).find();
+		return genericVariableCheckPattern.matcher(getMessage()).find();
 	}
 
 	protected Map<String, Pattern> getVariablePatternMap(Map<String, String> variableMap) {

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -16,12 +16,27 @@
 package nl.nn.testtool;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import nl.nn.testtool.run.ReportRunner;
+import nl.nn.testtool.run.RunResult;
+import nl.nn.testtool.storage.StorageException;
 import nl.nn.testtool.util.LogUtil;
+import nl.nn.testtool.util.XmlUtil;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.ws.security.util.DOM2Writer;
 import org.w3c.dom.Node;
+
+import net.sf.saxon.trans.XPathException;
 
 /**
  * @author Jaco de Groot
@@ -41,6 +56,12 @@ public class Checkpoint implements Serializable, Cloneable {
 	private int stub = STUB_FOLLOW_REPORT_STRATEGY;
 	private int preTruncatedMessageLength = -1;
 	private long estimatedMemoryUsage = -1;
+	private transient static Pattern simpleVariableCheckPattern;
+	private transient static Pattern externalVariablePattern;
+	static {
+		simpleVariableCheckPattern = Pattern.compile("\\$\\{.*?\\}");
+		externalVariablePattern = Pattern.compile("\\$\\{report\\((.*?)\\)\\/checkpoint\\(([0-9]+)\\)\\/xpath\\((.*?)\\)\\}");
+	}
 
 	public transient static final int TYPE_NONE = 0;
 	public transient static final int TYPE_STARTPOINT = 1;
@@ -235,5 +256,121 @@ public class Checkpoint implements Serializable, Cloneable {
 	
 	public void setEstimatedMemoryUsage(long estimatedMemoryUsage) {
 		this.estimatedMemoryUsage = estimatedMemoryUsage;
+	}
+
+	public String getMessageWithResolvedVariables(ReportRunner reportRunner) {
+		String result = getMessage();
+		if(getMessage() != null && containsVariables()) {
+			// 1. Parse interactive report variables
+			System.out.println("getMessageWithResolvedVariables() called");
+			if(reportRunner != null) {
+				List<MatchResult> matchResults = new ArrayList<MatchResult>();
+				Matcher m = externalVariablePattern.matcher(getMessage());
+				while(m.find()) {
+					matchResults.add(m.toMatchResult());
+				}
+				for(MatchResult matchResult : matchResults) {
+					String relativeReportPath = matchResult.group(1);
+					int checkpointIndex = Integer.parseInt(matchResult.group(2));
+					String xpathExpression = matchResult.group(3);
+					
+					// Determine the target report
+					String[] relativeReportPathSteps = relativeReportPath.split("/");
+					int[] operations = new int[relativeReportPathSteps.length];
+					for(int i = 0; i < relativeReportPathSteps.length; i++) {
+						String step = relativeReportPathSteps[i];
+						if(step.equals("..")) operations[i] = -1;
+						else if(step.equals(".")) operations[i] = 0;
+						else operations[i] = 1;
+					}
+					String determinedPath = report.getPath();
+					if(StringUtils.isEmpty(determinedPath)) determinedPath = "/";
+					String[] splitDeterminedPath = determinedPath.split("/");
+					for(int i = 0; i < operations.length; i++) {
+						switch(operations[i]) {
+							case -1:
+								determinedPath = determinedPath.substring(0, determinedPath.length() - splitDeterminedPath[splitDeterminedPath.length-1].length()-1);
+								break;
+							case 1:
+								determinedPath += relativeReportPathSteps[i] + (i < operations.length-1? "/" : "");
+								break;
+						}
+					}
+					Report targetReport = null;
+					try {
+						for(Entry<Integer, RunResult> entry : reportRunner.getResults().entrySet()) {
+							if(determinedPath.equals(entry.getValue().fullPath)) {
+								targetReport = reportRunner.getRunResultReport(entry.getValue().correlationId);
+								break;
+							}
+						}
+					} catch (StorageException e) {
+						log.error(e);
+					}
+					// Attempt to fetch data from xpath in target checkpoint's XML message
+					if(targetReport != null) {
+						try {
+							String targetXml = targetReport.getCheckpoints().get(checkpointIndex).getMessage();
+							if(StringUtils.isNotEmpty(targetXml)) {
+								try {
+									String xpathResult = XmlUtil.createXPathEvaluator(xpathExpression).evaluate(targetXml);
+									if(xpathResult != null) {
+										try {
+											result = result.replaceAll(Pattern.quote(matchResult.group()), xpathResult);
+										} catch (IllegalArgumentException e) {
+											if(xpathResult.matches("\\$\\{.*?\\}")) {
+												log.warn(warningMessageHeader(matchResult.group())
+														+"Specified xpath expression points to incorrectly parsed parameter "+xpathResult+"; "
+														+ "see other recent log warnings for a possible cause");
+											}
+										}
+									}
+								} catch (XPathException e) {
+									log.warn(warningMessageHeader(matchResult.group())+"Invalid xpath expression or XML message in target checkpoint");
+								}
+							} else {
+								log.warn(warningMessageHeader(matchResult.group())+"Target checkpoint ["+targetReport.getCheckpoints().get(checkpointIndex)+"] contains no message");
+							}
+						} catch (IndexOutOfBoundsException e) {
+							log.warn(warningMessageHeader(matchResult.group())+"Index out of bounds: checkpoint with index ["+checkpointIndex+"] does not exist in report ["+determinedPath+"]");
+						}
+					} else {
+						log.warn(warningMessageHeader(matchResult.group())+"Run result not found for report ["+determinedPath+"] - please make sure it runs before this report");
+					}
+				}
+			}
+			// 2. Parse dynamic variables
+			if(StringUtils.isNotEmpty(report.getVariableCsv())) {
+				Map<String, String> variableMap = report.getVariablesAsMap();
+				Map<String, Pattern> variablePatternMap = getVariablePatternMap(variableMap);
+				for(Entry<String, String> entry : variableMap.entrySet()) {
+					Matcher m = variablePatternMap.get(entry.getKey()).matcher(getMessage());
+					while(m.find()) {
+						result = result.replaceAll(Pattern.quote(m.group()), entry.getValue());
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	private String warningMessageHeader(String parameter) {
+		return "Could not parse parameter "+parameter+" found in the input of report ["+report.getFullPath()+"] with storageId ["+report.getStorageId()+"]\n"; 
+	}
+	
+	public boolean containsVariables() {
+		if(StringUtils.isEmpty(getMessage())) return false;
+		return simpleVariableCheckPattern.matcher(getMessage()).find();
+	}
+
+	private transient Map<String, Pattern> variablePatternMap;
+	Map<String, Pattern> getVariablePatternMap(Map<String, String> variableMap) {
+		if(variablePatternMap == null) {
+			variablePatternMap = new HashMap<String, Pattern>();
+			for(Entry<String, String> entry : variableMap.entrySet()) {
+				variablePatternMap.put(entry.getKey(), Pattern.compile("\\$\\{"+entry.getKey()+"\\}"));
+			}
+		}
+		return variablePatternMap;
 	}
 }

--- a/src/main/java/nl/nn/testtool/Debugger.java
+++ b/src/main/java/nl/nn/testtool/Debugger.java
@@ -17,6 +17,8 @@ package nl.nn.testtool;
 
 import java.util.List;
 
+import nl.nn.testtool.run.ReportRunner;
+
 /**
  * @author m00f069
  *
@@ -47,6 +49,6 @@ public interface Debugger {
 	 * @param originalReport  the original report that should be rerun
 	 * @return                an error message when an error occurred 
 	 */
-	public String rerun(String correlationId, Report originalReport, SecurityContext securityContext);
+	public String rerun(String correlationId, Report originalReport, SecurityContext securityContext, ReportRunner reportRunner);
 
 }

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -570,30 +570,17 @@ public class Report implements Serializable {
 		return "(name: " + name + ", type: " + Checkpoint.getTypeAsString(type) + ", level: " + level + ", correlationId: " + correlationId + ")";
 	}
 	
-	public boolean equalsOther(Report otherReport) {
-		return equalsOther(otherReport, null);
-	}
-
-	public boolean equalsOther(Report otherReport, ReportRunner reportRunner) {
-//		if(checkpoints.get(0).hasInputVariables()
-//		|| report.getCheckpoints().get(0).hasInputVariables()) {
-//			return toXml(true).equals(report.toXml(true));
-//		} else {
-			return toXml(reportRunner).equals(otherReport.toXml(reportRunner));
-//		}
-	}
-	
 	public String getVariableCsv() {
 		return variableCsv;
 	}
 	
-	public String setVariableCsv(String dynamicVariableCsv) {
-		if(StringUtils.isEmpty(dynamicVariableCsv)) {
+	public String setVariableCsv(String variableCsv) {
+		if(StringUtils.isEmpty(variableCsv)) {
 			this.variableCsv = null;
 			return null;
 		}
-		String errorMessage = CsvUtil.validateCsv(dynamicVariableCsv, ";", 2);
-		if(errorMessage == null) this.variableCsv = dynamicVariableCsv;
+		String errorMessage = CsvUtil.validateCsv(variableCsv, ";", 2);
+		if(errorMessage == null) this.variableCsv = variableCsv;
 		return errorMessage;
 	}
 
@@ -601,7 +588,7 @@ public class Report implements Serializable {
 		if(StringUtils.isEmpty(variableCsv)) {
 			return null;
 		}
-		Map<String, String> dynamicVariableMap = new LinkedHashMap<String, String>();
+		Map<String, String> variableMap = new LinkedHashMap<String, String>();
 		Scanner scanner = new Scanner(variableCsv);
 		List<String> lines = new ArrayList<String>();
 		while(scanner.hasNextLine()) {
@@ -615,9 +602,9 @@ public class Report implements Serializable {
 		List<String> params = Arrays.asList(lines.get(0).split(";"));
 		for(String key : params) {
 			String value = lines.get(1).split(";")[params.indexOf(key)];
-			dynamicVariableMap.put(key, value);
+			variableMap.put(key, value);
 		}
-		return dynamicVariableMap;
+		return variableMap;
 	}
 }
 

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -454,11 +454,7 @@ public class Report implements Serializable {
 	}
 
 	public MessageTransformer getMessageTransformer() {
-		if(testTool != null) {
-			return testTool.getMessageTransformer();
-		} else {
-			return null;
-		}
+		return testTool.getMessageTransformer();
 	}
 
 	public Object clone() throws CloneNotSupportedException {

--- a/src/main/java/nl/nn/testtool/Report.java
+++ b/src/main/java/nl/nn/testtool/Report.java
@@ -22,15 +22,24 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import nl.nn.testtool.run.ReportRunner;
+import nl.nn.testtool.run.RunResult;
 import nl.nn.testtool.storage.Storage;
+import nl.nn.testtool.storage.StorageException;
 import nl.nn.testtool.transform.MessageTransformer;
 import nl.nn.testtool.transform.ReportXmlTransformer;
 import nl.nn.testtool.util.EscapeUtil;
 import nl.nn.testtool.util.LogUtil;
+import nl.nn.testtool.util.XmlUtil;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
+import nl.nn.testtool.run.ReportRunner;
 import nl.nn.testtool.storage.LogStorage;
 import nl.nn.testtool.transform.MessageTransformer;
 import nl.nn.testtool.util.LogUtil;
@@ -263,13 +264,16 @@ public class TestTool {
 	}
 
 	public String rerun(Report report, SecurityContext securityContext) {
-		return rerun(null, report, securityContext);
+		return rerun(null, report, securityContext, null);
 	}
 
-	public String rerun(String correlationId, Report report, SecurityContext securityContext) {
+	public String rerun(String correlationId, Report report, SecurityContext securityContext, ReportRunner reportRunner) {
 		String errorMessage = null;
 		if (correlationId == null) {
 			correlationId = getCorrelationId();
+		}
+		if(report.hasInputVariables()) {
+			report.parseInputVariables(reportRunner);
 		}
 		boolean reportGeneratorEnabled = getReportGeneratorEnabled();
 		if (reportGeneratorEnabled) {

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -272,13 +272,6 @@ public class TestTool {
 		if (correlationId == null) {
 			correlationId = getCorrelationId();
 		}
-		if(report.hasInputVariables()) {
-			if(reportRunner != null) {
-				report.parseInputVariables(reportRunner);
-			} else {
-				log.warn("Input variable parsing does not (currently) work outside of the Test tab's rerun functionality");
-			}
-		}
 		boolean reportGeneratorEnabled = getReportGeneratorEnabled();
 		if (reportGeneratorEnabled) {
 			synchronized(originalReports) {
@@ -286,7 +279,7 @@ public class TestTool {
 			}
 		}
 		try {
-			errorMessage = debugger.rerun(correlationId, report, securityContext);
+			errorMessage = debugger.rerun(correlationId, report, securityContext, reportRunner);
 		} finally {
 			if (reportGeneratorEnabled) {
 				Report originalReport;

--- a/src/main/java/nl/nn/testtool/echo2/ComparePane.java
+++ b/src/main/java/nl/nn/testtool/echo2/ComparePane.java
@@ -253,7 +253,7 @@ public class ComparePane extends Tab implements BeanParent {
 	}
 
 	public void compare(Report report1, Report report2) {
-		if (report1.toXml().equals(report2.toXml())) {
+		if (report1.equalsOther(report2)) {
 			report1.setDifferenceFound(false);
 			report2.setDifferenceFound(false);
 		} else {
@@ -292,7 +292,7 @@ public class ComparePane extends Tab implements BeanParent {
 					if (i < ids2.size()) {
 						Integer id2 = (Integer)ids2.get(i);
 						Report report2 = storage2.getReport(id2);
-						if (report1.toXml().equals(report2.toXml())) {
+						if (report1.equalsOther(report2)) {
 							report1.setDifferenceFound(false);
 							report2.setDifferenceFound(false);
 						} else {

--- a/src/main/java/nl/nn/testtool/echo2/ComparePane.java
+++ b/src/main/java/nl/nn/testtool/echo2/ComparePane.java
@@ -30,6 +30,7 @@ import nl.nn.testtool.echo2.reports.ReportComponent;
 import nl.nn.testtool.echo2.reports.ReportsComponent;
 import nl.nn.testtool.echo2.reports.ReportsTreeCellRenderer;
 import nl.nn.testtool.echo2.reports.TreePane;
+import nl.nn.testtool.run.ReportRunner;
 import nl.nn.testtool.storage.CrudStorage;
 import nl.nn.testtool.storage.Storage;
 import nl.nn.testtool.storage.StorageException;
@@ -252,8 +253,8 @@ public class ComparePane extends Tab implements BeanParent {
 		infoPane2.initBean(this);
 	}
 
-	public void compare(Report report1, Report report2) {
-		if (report1.equalsOther(report2)) {
+	public void compare(Report report1, Report report2, ReportRunner reportRunner) {
+		if (report1.toXml(reportRunner).equals(report2.toXml(reportRunner))) {
 			report1.setDifferenceFound(false);
 			report2.setDifferenceFound(false);
 		} else {
@@ -292,7 +293,7 @@ public class ComparePane extends Tab implements BeanParent {
 					if (i < ids2.size()) {
 						Integer id2 = (Integer)ids2.get(i);
 						Report report2 = storage2.getReport(id2);
-						if (report1.equalsOther(report2)) {
+						if (report1.toXml().equals(report2.toXml())) {
 							report1.setDifferenceFound(false);
 							report2.setDifferenceFound(false);
 						} else {

--- a/src/main/java/nl/nn/testtool/echo2/Echo2Application.java
+++ b/src/main/java/nl/nn/testtool/echo2/Echo2Application.java
@@ -54,6 +54,7 @@ import nl.nn.testtool.echo2.reports.ReportComponent;
 import nl.nn.testtool.echo2.reports.ReportsComponent;
 import nl.nn.testtool.echo2.reports.ReportsTreeCellRenderer;
 import nl.nn.testtool.echo2.reports.TreePane;
+import nl.nn.testtool.run.ReportRunner;
 import nl.nn.testtool.storage.CrudStorage;
 import nl.nn.testtool.storage.Storage;
 import nl.nn.testtool.storage.StorageException;
@@ -379,7 +380,7 @@ public class Echo2Application extends ApplicationInstance implements Application
 		tabPane.setActiveTabIndex(activeTabIndexHistory.get(activeTabIndexHistory.size() - 1));
 	}
 
-	public void openReportCompare(Report report1, Report report2) {
+	public void openReportCompare(Report report1, Report report2, ReportRunner reportRunner) {
 		tabPane.setActiveTabIndex(2);
 		ComparePane comparePane = null;
 		for (Tab tab : tabs) {
@@ -391,7 +392,7 @@ public class Echo2Application extends ApplicationInstance implements Application
 		DefaultMutableTreeNode reportNode2;
 		reportNode1 = comparePane.getTreePane1().addReport(report1, comparePane.getReportsComponent1().getViews().getDefaultView(), false);
 		reportNode2 = comparePane.getTreePane2().addReport(report2, comparePane.getReportsComponent2().getViews().getDefaultView(), false);
-		comparePane.compare(report1, report2);
+		comparePane.compare(report1, report2, reportRunner);
 		comparePane.getTreePane1().selectNode(reportNode1);
 	}
 

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -171,7 +171,7 @@ public class CheckpointComponent extends MessageComponent {
 			
 			if(checkpoint.getPreTruncatedMessageLength() > 0) {
 				messageWasTruncatedLabel.setText("Message was truncated ("
-						+ (checkpoint.getPreTruncatedMessageLength() - testTool.getMaxMessageLength()) + " characters remaining)");
+						+ (checkpoint.getPreTruncatedMessageLength() - testTool.getMaxMessageLength()) + " characters removed)");
 				messageWasTruncatedLabel.setVisible(true);
 			} else {
 				messageWasTruncatedLabel.setVisible(false);

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -47,6 +47,8 @@ public class CheckpointComponent extends MessageComponent {
 	private RadioButton radioButtonStubOptionNo;
 	private Label messageHasBeenStubbedLabel;
 	private Label messageWasTruncatedLabel;
+	private Label checkpointIndexLabel;
+	private Label numberOfCharactersLabel;
 	private Label estimatedMemoryUsageLabel;
 
 	public CheckpointComponent() {
@@ -141,7 +143,13 @@ public class CheckpointComponent extends MessageComponent {
 		
 		pathLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(pathLabel);
+		
+		checkpointIndexLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
+		add(checkpointIndexLabel);
 
+		numberOfCharactersLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
+		add(numberOfCharactersLabel);
+		
 		estimatedMemoryUsageLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(estimatedMemoryUsageLabel);
 
@@ -189,7 +197,9 @@ public class CheckpointComponent extends MessageComponent {
 		nameLabel.setText("Name: " + checkpoint.getName());
 		threadNameLabel.setText("Thread name: " + checkpoint.getThreadName());
 		sourceClassNameLabel.setText("Source class name: " + checkpoint.getSourceClassName());
-		pathLabel.setText("Path: " + path + " (index: "+report.getCheckpoints().indexOf(checkpoint)+")");
+		pathLabel.setText("Path: " + path);
+		checkpointIndexLabel.setText("Checkpoint index: "+report.getCheckpoints().indexOf(checkpoint));
+		numberOfCharactersLabel.setText("Number of characters: "+(checkpoint.getMessage() != null ? checkpoint.getMessage().length() : "0"));
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + checkpoint.getEstimatedMemoryUsage() + " bytes");
 		hideMessages();
 	}

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -189,7 +189,7 @@ public class CheckpointComponent extends MessageComponent {
 		nameLabel.setText("Name: " + checkpoint.getName());
 		threadNameLabel.setText("Thread name: " + checkpoint.getThreadName());
 		sourceClassNameLabel.setText("Source class name: " + checkpoint.getSourceClassName());
-		pathLabel.setText("Path: " + path);
+		pathLabel.setText("Path: " + path + " (index: "+report.getCheckpoints().indexOf(checkpoint)+")");
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + checkpoint.getEstimatedMemoryUsage() + " bytes");
 		hideMessages();
 	}

--- a/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
@@ -235,7 +235,6 @@ public class ReportComponent extends MessageComponent {
 		
 		variableColumn = new Column();
 		variableColumn.setInsets(new Insets(0, 5, 0 ,0));
-//		addLineNumbers(dynamicParamColumn);
 		variableTextArea = new TextArea();
 		variableTextArea.setWidth(new Extent(50, Extent.PERCENT));
 		variableTextArea.setHeight(new Extent(32));
@@ -382,7 +381,7 @@ public class ReportComponent extends MessageComponent {
 		report.setName(nameTextField.getText());
 		report.setDescription(descriptionTextArea.getText());
 		saveReportPathChanges();
-		saveReportDynamicVariableChanges();
+		saveReportVariableChanges();
 		report.setTransformation(transformationTextArea.getText());
 		report.flushCachedXml();
 		if (report.getStorage() instanceof CrudStorage) {
@@ -401,7 +400,7 @@ public class ReportComponent extends MessageComponent {
 		report.setPath(input);
 	}
 
-	private void saveReportDynamicVariableChanges() {
+	private void saveReportVariableChanges() {
 		if(!variableTextArea.getText().equals(report.getVariableCsv())) {
 			String errorMessage = report.setVariableCsv(variableTextArea.getText());
 			if(errorMessage == null) {
@@ -422,7 +421,7 @@ public class ReportComponent extends MessageComponent {
 		updateDescriptionLabelAndDescriptionColumnAndTextArea();
 		updatePathLabelAndPathTextField();
 		updateTransformationLabelAndTransformationColumnAndTextArea();
-		updateDynamicVariableLabelAndTextArea();
+		updateVariableLabelAndTextArea();
 		if(!infoPane.edit()) {
 			variableErrorMessageLabel.setVisible(false);
 		}
@@ -484,7 +483,7 @@ public class ReportComponent extends MessageComponent {
 		transformationTextArea.setText(report.getTransformation());
 	}
 
-	private void updateDynamicVariableLabelAndTextArea() {
+	private void updateVariableLabelAndTextArea() {
 		if (infoPane.edit()) {
 			variableColumn.setVisible(false);
 			variableLabel.setVisible(true);

--- a/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
@@ -228,9 +228,9 @@ public class ReportComponent extends MessageComponent {
 				+ "These variables can be referred to in this report's input message by referring to their ${key}. "
 				+ "Example:\n\n"
 				+ "id;firstname;location\n"
-				+ "0;waldo;null\n\n"
+				+ "3;jaco;de groot\n\n"
 				+ "In this case, any occurences of ${firstname} in the report's input message "
-				+ "will be replaced with \"waldo\" at runtime.");
+				+ "will be replaced with \"jaco\" at runtime.");
 		dynamicVariableRow.add(dynamicVariableLabel);
 		
 		dynamicVariableColumn = new Column();
@@ -384,7 +384,6 @@ public class ReportComponent extends MessageComponent {
 		saveReportPathChanges();
 		saveReportDynamicVariableChanges();
 		report.setTransformation(transformationTextArea.getText());
-		report.setDynamicVariables(dynamicVariableTextArea.getText());
 		report.flushCachedXml();
 		if (report.getStorage() instanceof CrudStorage) {
 			displayAndLogError(Echo2Application.update((CrudStorage)report.getStorage(), report));
@@ -403,8 +402,8 @@ public class ReportComponent extends MessageComponent {
 	}
 
 	private void saveReportDynamicVariableChanges() {
-		if(!dynamicVariableTextArea.getText().equals(report.getDynamicVariableCsv())) {
-			String errorMessage = report.setDynamicVariables(dynamicVariableTextArea.getText());
+		if(!dynamicVariableTextArea.getText().equals(report.getVariableCsv())) {
+			String errorMessage = report.setVariableCsv(dynamicVariableTextArea.getText());
 			if(errorMessage == null) {
 				dynamicVariableErrorMessageLabel.setVisible(false);
 			} else {
@@ -495,11 +494,11 @@ public class ReportComponent extends MessageComponent {
 			dynamicVariableLabel.setVisible(false);
 			dynamicVariableTextArea.setVisible(false);
 		}
-		updateMessageColumn(report.getDynamicVariableCsv(), dynamicVariableColumn);
+		updateMessageColumn(report.getVariableCsv(), dynamicVariableColumn);
 		if (infoPane.showLineNumbers()) {
 			addLineNumbers(dynamicVariableColumn);
 		}
-		dynamicVariableTextArea.setText(report.getDynamicVariableCsv());
+		dynamicVariableTextArea.setText(report.getVariableCsv());
 	}
 
 	@Override

--- a/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
@@ -65,10 +65,10 @@ public class ReportComponent extends MessageComponent {
 	private TextArea transformationTextArea;
 	private WindowPane deleteWarningWindow;
 	private Label deleteIdLabel;
-	private Label dynamicVariableLabel;
-	private Column dynamicVariableColumn;
-	private TextArea dynamicVariableTextArea;
-	private Label dynamicVariableErrorMessageLabel;
+	private Label variableLabel;
+	private Column variableColumn;
+	private TextArea variableTextArea;
+	private Label variableErrorMessageLabel;
 
 	public ReportComponent() {
 		super();
@@ -153,9 +153,9 @@ public class ReportComponent extends MessageComponent {
 		add(messageColumn);
 		add(messageTextArea);
 		
-		dynamicVariableErrorMessageLabel = Echo2Application.createErrorLabel();
-		dynamicVariableErrorMessageLabel.setVisible(false);
-		add(dynamicVariableErrorMessageLabel);
+		variableErrorMessageLabel = Echo2Application.createErrorLabel();
+		variableErrorMessageLabel.setVisible(false);
+		add(variableErrorMessageLabel);
 		
 		buttonRow = Echo2Application.getNewRow();
 		add(buttonRow);
@@ -217,30 +217,30 @@ public class ReportComponent extends MessageComponent {
 		transformationTextArea.setVisible(false);
 		add(transformationTextArea);
 		
-		Row dynamicVariableRow = Echo2Application.getNewRow();
-		dynamicVariableRow.setInsets(new Insets(0, 5, 0 ,0));
-		add(dynamicVariableRow);
+		Row variableRow = Echo2Application.getNewRow();
+		variableRow.setInsets(new Insets(0, 5, 0 ,0));
+		add(variableRow);
 		
-		dynamicVariableLabel = Echo2Application.createInfoLabel();
-		dynamicVariableLabel.setText("Dynamic variables:");
-		dynamicVariableLabel.setVisible(false);
-		dynamicVariableLabel.setToolTipText("A map of variables to be written in CSV-format with delimiter ';'. "
+		variableLabel = Echo2Application.createInfoLabel();
+		variableLabel.setText("Variables:");
+		variableLabel.setVisible(false);
+		variableLabel.setToolTipText("A map of variables to be written in CSV-format with delimiter ';'. "
 				+ "These variables can be referred to in this report's input message by referring to their ${key}. "
 				+ "Example:\n\n"
 				+ "id;firstname;location\n"
 				+ "3;jaco;de groot\n\n"
 				+ "In this case, any occurences of ${firstname} in the report's input message "
 				+ "will be replaced with \"jaco\" at runtime.");
-		dynamicVariableRow.add(dynamicVariableLabel);
+		variableRow.add(variableLabel);
 		
-		dynamicVariableColumn = new Column();
-		dynamicVariableColumn.setInsets(new Insets(0, 5, 0 ,0));
+		variableColumn = new Column();
+		variableColumn.setInsets(new Insets(0, 5, 0 ,0));
 //		addLineNumbers(dynamicParamColumn);
-		dynamicVariableTextArea = new TextArea();
-		dynamicVariableTextArea.setWidth(new Extent(50, Extent.PERCENT));
-		dynamicVariableTextArea.setHeight(new Extent(32));
-		dynamicVariableTextArea.setVisible(false);
-		add(dynamicVariableTextArea);
+		variableTextArea = new TextArea();
+		variableTextArea.setWidth(new Extent(50, Extent.PERCENT));
+		variableTextArea.setHeight(new Extent(32));
+		variableTextArea.setVisible(false);
+		add(variableTextArea);
 
 		storageIdLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(storageIdLabel);
@@ -402,16 +402,16 @@ public class ReportComponent extends MessageComponent {
 	}
 
 	private void saveReportDynamicVariableChanges() {
-		if(!dynamicVariableTextArea.getText().equals(report.getVariableCsv())) {
-			String errorMessage = report.setVariableCsv(dynamicVariableTextArea.getText());
+		if(!variableTextArea.getText().equals(report.getVariableCsv())) {
+			String errorMessage = report.setVariableCsv(variableTextArea.getText());
 			if(errorMessage == null) {
-				dynamicVariableErrorMessageLabel.setVisible(false);
+				variableErrorMessageLabel.setVisible(false);
 			} else {
-				dynamicVariableErrorMessageLabel.setText("[Dynamic variables] "+errorMessage);
-				dynamicVariableErrorMessageLabel.setVisible(true);
+				variableErrorMessageLabel.setText("[Variables] "+errorMessage);
+				variableErrorMessageLabel.setVisible(true);
 			}
 		} else {
-			dynamicVariableErrorMessageLabel.setVisible(false);
+			variableErrorMessageLabel.setVisible(false);
 		}
 	}
 
@@ -424,7 +424,7 @@ public class ReportComponent extends MessageComponent {
 		updateTransformationLabelAndTransformationColumnAndTextArea();
 		updateDynamicVariableLabelAndTextArea();
 		if(!infoPane.edit()) {
-			dynamicVariableErrorMessageLabel.setVisible(false);
+			variableErrorMessageLabel.setVisible(false);
 		}
 	}
 
@@ -486,19 +486,19 @@ public class ReportComponent extends MessageComponent {
 
 	private void updateDynamicVariableLabelAndTextArea() {
 		if (infoPane.edit()) {
-			dynamicVariableColumn.setVisible(false);
-			dynamicVariableLabel.setVisible(true);
-			dynamicVariableTextArea.setVisible(true);
+			variableColumn.setVisible(false);
+			variableLabel.setVisible(true);
+			variableTextArea.setVisible(true);
 		} else {
-			dynamicVariableColumn.setVisible(true);
-			dynamicVariableLabel.setVisible(false);
-			dynamicVariableTextArea.setVisible(false);
+			variableColumn.setVisible(true);
+			variableLabel.setVisible(false);
+			variableTextArea.setVisible(false);
 		}
-		updateMessageColumn(report.getVariableCsv(), dynamicVariableColumn);
+		updateMessageColumn(report.getVariableCsv(), variableColumn);
 		if (infoPane.showLineNumbers()) {
-			addLineNumbers(dynamicVariableColumn);
+			addLineNumbers(variableColumn);
 		}
-		dynamicVariableTextArea.setText(report.getVariableCsv());
+		variableTextArea.setText(report.getVariableCsv());
 	}
 
 	@Override

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -493,10 +493,10 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private Label newDynamicVariableLabel(Report report) {
 		Label label = new Label();
 		label.setForeground(Echo2Application.getButtonRolloverBackgroundColor());
-		if(report.getDynamicVariableCsv() != null) {
+		if(report.getVariableCsv() != null) {
 			String labelText = "[";
 			boolean tooManyChars = false;
-			for(Entry<String, String> entry : report.getDynamicVariableMap().entrySet()) {
+			for(Entry<String, String> entry : report.getVariablesAsMap().entrySet()) {
 				if(labelText.length() + entry.getValue().length() < 50) {
 					labelText += entry.getKey()+"="+entry.getValue()+", ";
 				} else {
@@ -527,7 +527,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
 		runResultReport.setTransformation(report.getTransformation());
 		runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-		if (report.equalsOther(runResultReport)) {
+		if (report.equalsOther(runResultReport, reportRunner)) {
 			label.setForeground(Echo2Application.getNoDifferenceFoundTextColor());
 		} else {
 			label.setForeground(Echo2Application.getDifferenceFoundTextColor());
@@ -720,13 +720,13 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 					runResultReport = getRunResultReport(reportRunner.getResults().get(storageId).correlationId);
 					runResultReport.setName(report.getName());
 					runResultReport.setDescription(report.getDescription());
-					if(report.hasInputVariables()) {
+					if(report.getCheckpoints().get(0).containsVariables()) {
 						runResultReport.getCheckpoints().get(0).setMessage(report.getCheckpoints().get(0).getMessage());
 					}
 					runResultReport.setPath(report.getPath());
 					runResultReport.setTransformation(report.getTransformation());
 					runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-					runResultReport.setDynamicVariables(report.getDynamicVariableCsv());
+					runResultReport.setVariableCsv(report.getVariableCsv());
 					errorMessage = Echo2Application.store(runStorage, runResultReport);
 					reportRunner.getResults().remove(storageId);
 					row.setId(runResultReport.getStorageId().toString());
@@ -774,12 +774,12 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		scanner.close();
 		
 		try {
-			report.setDynamicVariables(lines.get(0)+"\n"+lines.get(1));
+			report.setVariableCsv(lines.get(0)+"\n"+lines.get(1));
 			displayAndLogError(Echo2Application.update(runStorage, report));
 			if(lines.size() > 2) {
 				for(int i = 2; i < lines.size(); i++) {
 					Report cloneReport = (Report)report.clone();
-					cloneReport.setDynamicVariables(lines.get(0)+"\n"+lines.get(i));
+					cloneReport.setVariableCsv(lines.get(0)+"\n"+lines.get(i));
 					displayAndLogError(Echo2Application.store(runStorage, cloneReport));
 				}
 			}

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -409,7 +409,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 						runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
 						runResultReport.setTransformation(report.getTransformation());
 						runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-						if (report.toXml().equals(runResultReport.toXml())) {
+						if (report.equalsOther(runResultReport)) {
 							label.setForeground(Echo2Application.getNoDifferenceFoundTextColor());
 						} else {
 							label.setForeground(Echo2Application.getDifferenceFoundTextColor());

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -190,6 +190,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		buttonRow.add(progressBar);
 		reportRunner = new ReportRunner();
 		reportRunner.setTestTool(testTool);
+		reportRunner.setDebugStorage(debugStorage);
 
 		Row uploadSelectRow = new Row();
 

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -671,7 +671,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private Report getRunResultReport(String runResultCorrelationId) {
 		Report report = null;
 		try {
-			report = ReportRunner.getRunResultReport(debugStorage, runResultCorrelationId);
+			report = reportRunner.getRunResultReport(runResultCorrelationId);
 		} catch(StorageException storageException) {
 			displayAndLogError(storageException);
 		}

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -21,10 +21,15 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Scanner;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TooManyListenersException;
 
+import org.apache.commons.lang.StringUtils;
+
 import echopointng.ProgressBar;
+import echopointng.tree.DefaultTreeCellRenderer;
 import nextapp.echo2.app.Button;
 import nextapp.echo2.app.CheckBox;
 import nextapp.echo2.app.Column;
@@ -34,6 +39,7 @@ import nextapp.echo2.app.FillImageBorder;
 import nextapp.echo2.app.Insets;
 import nextapp.echo2.app.Label;
 import nextapp.echo2.app.Row;
+import nextapp.echo2.app.TextArea;
 import nextapp.echo2.app.TextField;
 import nextapp.echo2.app.WindowPane;
 import nextapp.echo2.app.event.ActionEvent;
@@ -57,6 +63,7 @@ import nl.nn.testtool.storage.CrudStorage;
 import nl.nn.testtool.storage.Storage;
 import nl.nn.testtool.storage.StorageException;
 import nl.nn.testtool.transform.ReportXmlTransformer;
+import nl.nn.testtool.util.CsvUtil;
 
 /**
  * @author m00f069
@@ -76,11 +83,23 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private TextField pathTextField;
 	private ReportXmlTransformer reportXmlTransformer = null;
 	private WindowPane uploadWindow;
+	private WindowPane reportGenerationWindow;
 	private UploadSelect uploadSelect;
 	private int numberOfComponentsToSkipForRowManipulation = 0;
 	private String lastDisplayedPath;
 	private BeanParent beanParent;
-
+	
+	private TextArea cloneGenerationTextArea;
+	private Label reportGenerationWarningLabel;
+	
+	private int COMPONENT_CHECKBOX = 0;
+	private int COMPONENT_RUN_BUTTON = 1;
+	private int COMPONENT_OPEN_BUTTON = 2;
+	private int COMPONENT_COMPARE_BUTTON = 3;
+	private int COMPONENT_REPLACE_BUTTON = 4;
+	private int COMPONENT_RESULT_LABEL = 5;
+	private int COMPONENT_DYNAMIC_VAR_LABEL = 6;
+	
 	public RunComponent() {
 		super();
 	}
@@ -111,18 +130,31 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 
 		// TODO code voor aanmaken upload window en ander zaken gaan delen met ReportsComponent
 		Column uploadColumn = new Column();
+		Column cloneGenerationColumn = new Column();
 
 		uploadWindow = new WindowPane();
 		uploadWindow.setVisible(false);
 		uploadWindow.setTitle("Upload");
 		uploadWindow.setTitleBackground(Echo2Application.getButtonBackgroundColor());
 		uploadWindow.setBorder(new FillImageBorder(Echo2Application.getButtonBackgroundColor(), new Insets(0, 0, 0, 0), new Insets(0, 0, 0, 0)));
-		uploadWindow.setWidth(new Extent(350));
-		uploadWindow.setHeight(new Extent(110));
+		uploadWindow.setWidth(new Extent(480));
+		uploadWindow.setHeight(new Extent(360));
 		uploadWindow.setInsets(new Insets(10, 0, 10, 0));
 		uploadWindow.add(uploadColumn);
 		uploadWindow.setDefaultCloseOperation(WindowPane.HIDE_ON_CLOSE);
 		uploadWindow.init();
+		
+		reportGenerationWindow = new WindowPane();
+		reportGenerationWindow.setTitle("Generate dynamic report clones from CSV");
+//		reportGenerationWindow.setTitleBackground(Echo2Application.getButtonBackgroundColor());
+//		reportGenerationWindow.setBorder(new FillImageBorder(Echo2Application.getButtonBackgroundColor(), new Insets(0, 0, 0, 0), new Insets(0, 0, 0, 0)));
+		reportGenerationWindow.setVisible(false);
+		reportGenerationWindow.setWidth(new Extent(464));
+		reportGenerationWindow.setHeight(new Extent(348));
+		reportGenerationWindow.setInsets(new Insets(5, 5, 5, 5));
+		reportGenerationWindow.add(cloneGenerationColumn);
+		reportGenerationWindow.setDefaultCloseOperation(WindowPane.HIDE_ON_CLOSE);
+		reportGenerationWindow.init();
 
 		Row buttonRow = Echo2Application.getNewRow();
 
@@ -167,6 +199,18 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		copySelectedButton.addActionListener(this);
 		Echo2Application.decorateButton(copySelectedButton);
 		buttonRow.add(copySelectedButton);
+
+		Button cloneSelectedButton = new Button("Clone");
+		cloneSelectedButton.setToolTipText(
+				"Generates clone reports based on a custom CSV-formatted table of parameters and their values. "
+				+ "Example:\n\nid;firstname;lastname\n0;jaco;de groot\n1;daniel;meyer\n\nOne clone report is made "
+				+ "for every row of values - two in this case. The parameters can be referred to in each report's "
+				+ "input message by writing, for example, ${firstname}, which would be parsed to the corresponding "
+				+ "value for that parameter at runtime.");
+		cloneSelectedButton.setActionCommand("CloneSelected");
+		cloneSelectedButton.addActionListener(this);
+		Echo2Application.decorateButton(cloneSelectedButton);
+		buttonRow.add(cloneSelectedButton);
 
 		Button deleteSelectedButton = new Button("Delete");
 		deleteSelectedButton.setActionCommand("DeleteSelected");
@@ -222,6 +266,31 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		uploadSelectRow.add(uploadSelect);
 		uploadColumn.add(uploadSelectRow);
 
+		// Report generation window
+		Row cloneGenerationWarningLabelRow = Echo2Application.getNewRow();
+		Row cloneGenerationTextFieldRow = Echo2Application.getNewRow();
+		Row cloneGenerationButtonRow = Echo2Application.getNewRow();
+		
+		reportGenerationWarningLabel = Echo2Application.createErrorLabel();
+		reportGenerationWarningLabel.setVisible(false);
+		
+		cloneGenerationTextArea = new TextArea();
+		cloneGenerationTextArea.setWidth(new Extent(440));
+		cloneGenerationTextArea.setHeight(new Extent(240));
+		
+		Button generateClonesButton = new Button("Generate");
+		generateClonesButton.setActionCommand("GenerateClonesFromCsv");
+		generateClonesButton.addActionListener(this);
+		Echo2Application.decorateButton(generateClonesButton);
+
+		cloneGenerationWarningLabelRow.add(reportGenerationWarningLabel);
+		cloneGenerationTextFieldRow.add(cloneGenerationTextArea);
+		cloneGenerationButtonRow.add(generateClonesButton);
+		cloneGenerationColumn.add(cloneGenerationWarningLabelRow);
+		cloneGenerationColumn.add(cloneGenerationTextFieldRow);
+		cloneGenerationColumn.add(cloneGenerationButtonRow);
+		//
+
 		add(buttonRow);
 		numberOfComponentsToSkipForRowManipulation++;
 
@@ -242,6 +311,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		this.beanParent = beanParent;
 		this.echo2Application = Echo2Application.getEcho2Application(beanParent, this);
 		echo2Application.getContentPane().add(uploadWindow);
+		echo2Application.getContentPane().add(reportGenerationWindow);
 		RunPane runPane = (RunPane)beanParent.getBeanParent();
 		treePane = runPane.getTreePane();
 		reportRunner.setSecurityContext(echo2Application);
@@ -346,27 +416,36 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	}
 
 	private void displayReport(String storageId, String path, String name, String description, boolean selected) {
+		Report report = null;
+		try {
+			report = runStorage.getReport(Integer.parseInt(storageId));
+		} catch (StorageException e) {
+			displayAndLogError(e);
+		}
+		
 		Row row = Echo2Application.getNewRow();
 		row.setId(storageId);
 		row.setInsets(new Insets(0, 5, 0, 0));
-
+		
 		CheckBox checkBox = new CheckBox("");
 		checkBox.setSelected(selected);
 		row.add(checkBox);
+		// When adding a new element to the row, raise the indices of all components
+		// by adjusting the "COMPONENT_*" final variables of this class
 
-		Button button = new Button("Run");
-		button.setActionCommand("Run");
-		button.addActionListener(this);
-		Echo2Application.decorateButton(button);
-		row.add(button);
+		Button runButton = new Button("Run");
+		runButton.setActionCommand("Run");
+		runButton.addActionListener(this);
+		Echo2Application.decorateButton(runButton);
+		row.add(runButton);
 
-		button = new Button("Open");
-		button.setActionCommand("Open");
-		button.addActionListener(this);
-		Echo2Application.decorateButton(button);
-		row.add(button);
+		Button openButton = new Button("Open");
+		openButton.setActionCommand("Open");
+		openButton.addActionListener(this);
+		Echo2Application.decorateButton(openButton);
+		row.add(openButton);
 
-		button = new Button("Compare");
+		Button button = new Button("Compare");
 		button.setActionCommand("Compare");
 		button.addActionListener(this);
 		button.setVisible(false);
@@ -381,6 +460,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		row.add(button);
 
 		Label label = new Label(path + name);
+		row.add(label);
 		RunResult runResult = reportRunner.getResults().get(Integer.parseInt(storageId));
 		if (runResult != null) {
 			if (runResult.errorMessage != null) {
@@ -392,39 +472,15 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 					label = Echo2Application.createErrorLabel();
 					label.setText("Result report not found. Report generator not enabled?");
 				} else {
-					Report report = null;
-					try {
-						report = runStorage.getReport(Integer.parseInt(storageId));
-					} catch (StorageException e) {
-						displayAndLogError(e);
-					}
-					if (report != null) {
-						String stubInfo = "";
-						if (!"Never".equals(report.getStubStrategy())) {
-							stubInfo = " (" + report.getStubStrategy() + ")";
-						}
-						label.setText(path + name + " (" + (report.getEndTime() - report.getStartTime()) + " >> "
-								+ (runResultReport.getEndTime() - runResultReport.getStartTime()) + " ms)" + stubInfo);
-						report.setGlobalReportXmlTransformer(reportXmlTransformer);
-						runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
-						runResultReport.setTransformation(report.getTransformation());
-						runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-						if (report.equalsOther(runResultReport)) {
-							label.setForeground(Echo2Application.getNoDifferenceFoundTextColor());
-						} else {
-							label.setForeground(Echo2Application.getDifferenceFoundTextColor());
-						}
-						Button compareButton = (Button)row.getComponent(3);
-						compareButton.setVisible(true);
-						Button replaceButton = (Button)row.getComponent(4);
-						replaceButton.setVisible(true);
+					if(report != null) {
+						updateRow(row);
 					}
 				}
 			}
 		}
-		row.add(label);
+		row.add(newDynamicVariableLabel(report));
+		
 		add(row);
-
 		// TODO runStorage.getMetadata geeft blijkbaar "null" terug, fixen
 		if (description != null && !"".equals(description) && !"null".equals(description)) {
 			Column descriptionColumn = new Column();
@@ -434,6 +490,52 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		}
 	}
 
+	private Label newDynamicVariableLabel(Report report) {
+		Label label = new Label();
+		label.setForeground(Echo2Application.getButtonRolloverBackgroundColor());
+		if(report.getDynamicVariableCsv() != null) {
+			String labelText = "[";
+			boolean tooManyChars = false;
+			for(Entry<String, String> entry : report.getDynamicVariableMap().entrySet()) {
+				if(labelText.length() + entry.getValue().length() < 50) {
+					labelText += entry.getKey()+"="+entry.getValue()+", ";
+				} else {
+					tooManyChars = true;
+					break;
+				}
+			}
+			labelText = labelText.substring(0, labelText.length()-2) + (tooManyChars? "...]" : "]");
+			label.setText(labelText);
+		} else {
+			label.setVisible(false);
+		}
+		return label;
+	}
+
+	private void updateRow(Row row) {
+		Report report = getReport(row);
+		RunResult runResult = reportRunner.getResults().get((Integer)report.getStorageId());
+		Report runResultReport = getRunResultReport(runResult.correlationId);
+		Label label = (Label)row.getComponent(COMPONENT_RESULT_LABEL);
+		String stubInfo = "";
+		if (!"Never".equals(report.getStubStrategy())) {
+			stubInfo = " (" + report.getStubStrategy() + ")";
+		}
+		label.setText(report.getFullPath() + " (" + (report.getEndTime() - report.getStartTime()) + " >> "
+				+ (runResultReport.getEndTime() - runResultReport.getStartTime()) + " ms)" + stubInfo);
+		report.setGlobalReportXmlTransformer(reportXmlTransformer);
+		runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
+		runResultReport.setTransformation(report.getTransformation());
+		runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
+		if (report.equalsOther(runResultReport)) {
+			label.setForeground(Echo2Application.getNoDifferenceFoundTextColor());
+		} else {
+			label.setForeground(Echo2Application.getDifferenceFoundTextColor());
+		}
+		((Button)row.getComponent(COMPONENT_COMPARE_BUTTON)).setVisible(true);
+		((Button)row.getComponent(COMPONENT_REPLACE_BUTTON)).setVisible(true);
+	}
+	
 	/**
 	 * @see nextapp.echo2.app.event.ActionListener#actionPerformed(nextapp.echo2.app.event.ActionEvent)
 	 */
@@ -446,7 +548,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 			refresh();
 		} else if (e.getActionCommand().equals("SelectAll") || e.getActionCommand().equals("DeselectAll")) {
 			for (Row row : getReportRows()) {
-				CheckBox checkbox = (CheckBox)row.getComponent(0);
+				CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
 				if (e.getActionCommand().equals("SelectAll")) {
 					checkbox.setSelected(true);
 				} else {
@@ -457,7 +559,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 			if (minimalOneSelected()) {
 				List<Row> rows = new ArrayList<Row>();
 				for (Row row : getReportRows()) {
-					CheckBox checkbox = (CheckBox)row.getComponent(0);
+					CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
 					if (checkbox.isSelected()) {
 						rows.add(row);
 					}
@@ -491,14 +593,16 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 				actionLabels.add("No, cancel this action");
 				actionCommands.add("DeleteCancel");
 				actionListeners.add(this);
-				PopupWindow popupWindow = new PopupWindow("",
-						"Are you sure you want to delete all selected reports?", 450, 100,
+				int reportsSelected = getSelectedReportCount();
+				String popupMessage = reportsSelected > 1 ? "Are you sure you want to delete the "+reportsSelected+" selected reports?"
+						: "Are you sure you want to delete the selected report?";
+				PopupWindow popupWindow = new PopupWindow("", popupMessage, 450, 100,
 						actionLabels, actionCommands, actionListeners);
 				echo2Application.getContentPane().add(popupWindow);
 			}
 		} else if (e.getActionCommand().equals("DeleteOk")) {
 			for (Row row : getReportRows()) {
-				CheckBox checkbox = (CheckBox)row.getComponent(0);
+				CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
 				if (checkbox.isSelected()) {
 					Report report = getReport(row);
 					if (report != null) {
@@ -517,7 +621,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 			if (minimalOneSelected()) {
 				String newPath = normalizePath(pathTextField.getText());
 				for (Row row : getReportRows()) {
-					CheckBox checkbox = (CheckBox)row.getComponent(0);
+					CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
 					if (checkbox.isSelected()) {
 						movePath(row, newPath);
 					}
@@ -544,6 +648,34 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 				} else {
 					copyPath(newPath);
 					treePane.redisplayReports(newPath, null);
+				}
+			}
+		} else if (e.getActionCommand().equals("CloneSelected")) {
+			reportGenerationWindow.setVisible(true);
+		} else if (e.getActionCommand().equals("GenerateClonesFromCsv")) {
+			if (minimalOneSelected()) {
+				String errorMessage = CsvUtil.validateCsv(cloneGenerationTextArea.getText(), ";");
+				if(errorMessage == null) {
+					if(getSelectedReportCount() > 1
+							&& (reportGenerationWarningLabel.getText() == null
+							|| !reportGenerationWarningLabel.getText().endsWith("press again to confirm"))) {
+						reportGenerationWarningLabel.setText("More than one report selected to clone; press again to confirm");
+						reportGenerationWarningLabel.setVisible(true);
+					} else {
+						for (Row row : getReportRows()) {
+							CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
+							if (checkbox.isSelected()) {
+								generateReportClonesFromCsv(getReport(row));
+							}
+						}
+						reportGenerationWindow.setVisible(false);
+						reportGenerationWarningLabel.setText(null);
+						reportGenerationWarningLabel.setVisible(false);
+						refresh();
+					}
+				} else {
+					reportGenerationWarningLabel.setText(errorMessage);
+					reportGenerationWarningLabel.setVisible(true);
 				}
 			}
 		} else if (e.getActionCommand().equals("Run")) {
@@ -588,21 +720,27 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 					runResultReport = getRunResultReport(reportRunner.getResults().get(storageId).correlationId);
 					runResultReport.setName(report.getName());
 					runResultReport.setDescription(report.getDescription());
+					if(report.hasInputVariables()) {
+						runResultReport.getCheckpoints().get(0).setMessage(report.getCheckpoints().get(0).getMessage());
+					}
 					runResultReport.setPath(report.getPath());
 					runResultReport.setTransformation(report.getTransformation());
 					runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
+					runResultReport.setDynamicVariables(report.getDynamicVariableCsv());
 					errorMessage = Echo2Application.store(runStorage, runResultReport);
 					reportRunner.getResults().remove(storageId);
 					row.setId(runResultReport.getStorageId().toString());
-					row.getComponent(4).setVisible(false);
-					row.getComponent(5).setVisible(false);
-					row.remove(6);
+					row.getComponent(COMPONENT_COMPARE_BUTTON).setVisible(false);
+					row.getComponent(COMPONENT_REPLACE_BUTTON).setVisible(false);
+					row.remove(COMPONENT_DYNAMIC_VAR_LABEL);
+					row.remove(COMPONENT_RESULT_LABEL);
 					String path = runResultReport.getPath();
 					String name = runResultReport.getName();
 					if (path == null || !path.equals(normalizePath(path))) {
 						path = "/";
 					}
 					row.add(new Label(path + name));
+					row.add(newDynamicVariableLabel(report));
 				}
 				if (errorMessage == null) {
 					errorMessage = Echo2Application.delete(runStorage, report);
@@ -616,10 +754,48 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 						}
 					}
 				}
-				displayAndLogError(errorMessage);
+				if(errorMessage != null) {
+					displayAndLogError(errorMessage);
+				}
 			}
 		}
 		updateProgressBar();
+	}
+
+	private void generateReportClonesFromCsv(Report report) {
+		Scanner scanner = new Scanner(cloneGenerationTextArea.getText());
+		List<String> lines = new ArrayList<String>();
+		while(scanner.hasNextLine()) {
+			String nextLine = scanner.nextLine();
+			if(StringUtils.isNotEmpty(nextLine) && !nextLine.startsWith("#")) {
+				lines.add(nextLine);
+			}
+		}
+		scanner.close();
+		
+		try {
+			report.setDynamicVariables(lines.get(0)+"\n"+lines.get(1));
+			displayAndLogError(Echo2Application.update(runStorage, report));
+			if(lines.size() > 2) {
+				for(int i = 2; i < lines.size(); i++) {
+					Report cloneReport = (Report)report.clone();
+					cloneReport.setDynamicVariables(lines.get(0)+"\n"+lines.get(i));
+					displayAndLogError(Echo2Application.store(runStorage, cloneReport));
+				}
+			}
+		} catch (CloneNotSupportedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private int getSelectedReportCount() {
+		int count = 0;
+		for(Row row : getReportRows()) {
+			if(((CheckBox)row.getComponent(COMPONENT_CHECKBOX)).isSelected()) {
+				count++;
+			}
+		}
+		return count;
 	}
 
 	private void updateProgressBar() {
@@ -647,7 +823,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private Set<String> getSelectedStorageIds() {
 		Set<String> selectedStorageIds = new HashSet<String>();
 		for (Row row : getReportRows()) {
-			CheckBox checkbox = (CheckBox)row.getComponent(0);
+			CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
 			if (checkbox.isSelected()) {
 				selectedStorageIds.add(row.getId());
 			}
@@ -717,7 +893,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 
 	private void copyPath(String newPath) {
 		for (Row row : getReportRows()) {
-			CheckBox checkbox = (CheckBox)row.getComponent(0);
+			CheckBox checkbox = (CheckBox)row.getComponent(COMPONENT_CHECKBOX);
 			if (checkbox.isSelected()) {
 				copyPath(row, newPath);
 			}

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -527,7 +527,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
 		runResultReport.setTransformation(report.getTransformation());
 		runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-		if (report.equalsOther(runResultReport, reportRunner)) {
+		if (report.toXml(reportRunner).equals(runResultReport.toXml(reportRunner))) {
 			label.setForeground(Echo2Application.getNoDifferenceFoundTextColor());
 		} else {
 			label.setForeground(Echo2Application.getDifferenceFoundTextColor());
@@ -704,7 +704,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 					runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
 					runResultReport.setTransformation(report.getTransformation());
 					runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
-					echo2Application.openReportCompare(report, runResultReport);
+					echo2Application.openReportCompare(report, runResultReport, reportRunner);
 				}
 			}
 		} else if (e.getActionCommand().equals("Delete")

--- a/src/main/java/nl/nn/testtool/run/ReportRunner.java
+++ b/src/main/java/nl/nn/testtool/run/ReportRunner.java
@@ -38,9 +38,14 @@ public class ReportRunner implements Runnable {
 	private int maximum = 1;
 	private Map<Integer, RunResult> results = Collections.synchronizedMap(new HashMap<Integer, RunResult>());
 	private boolean running = false;
+	private Storage debugStorage;
 
 	public void setTestTool(TestTool testTool) {
 		this.testTool = testTool;
+	}
+
+	public void setDebugStorage(Storage debugStorage) {
+		this.debugStorage = debugStorage;
 	}
 
 	public void setSecurityContext(SecurityContext securityContext) {
@@ -88,7 +93,8 @@ public class ReportRunner implements Runnable {
 	private void run(Report report) {
 		RunResult runResult = new RunResult();
 		runResult.correlationId = TestTool.getCorrelationId();
- 		runResult.errorMessage = testTool.rerun(runResult.correlationId, report, securityContext);
+ 		runResult.errorMessage = testTool.rerun(runResult.correlationId, report, securityContext, this);
+ 		runResult.fullPath = report.getFullPath();
 		results.put(report.getStorageId(), runResult);
 	}
 
@@ -104,7 +110,7 @@ public class ReportRunner implements Runnable {
 		return results;
 	}
 
-	public static Report getRunResultReport(Storage debugStorage, String runResultCorrelationId)
+	public Report getRunResultReport(String runResultCorrelationId)
 			throws StorageException {
 		Report report = null;
 		List<String> metadataNames = new ArrayList<String>();
@@ -122,5 +128,9 @@ public class ReportRunner implements Runnable {
 			report = debugStorage.getReport(runResultStorageId);
 		}
 		return report;
+	}
+
+	public Storage getDebugStorage() {
+		return debugStorage;
 	}
 }

--- a/src/main/java/nl/nn/testtool/run/RunResult.java
+++ b/src/main/java/nl/nn/testtool/run/RunResult.java
@@ -21,4 +21,5 @@ package nl.nn.testtool.run;
 public class RunResult {
 	public String errorMessage;
 	public String correlationId;
+	public String fullPath;
 }

--- a/src/main/java/nl/nn/testtool/util/CsvUtil.java
+++ b/src/main/java/nl/nn/testtool/util/CsvUtil.java
@@ -1,0 +1,50 @@
+package nl.nn.testtool.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+import org.apache.commons.lang.StringUtils;
+
+public class CsvUtil {
+
+	/**
+     * 
+     * @return An error message as a result of unsuccessful validation;
+     * null if validation was successful.
+     */
+	public static String validateCsv(String text, String delimiter) {
+		return validateCsv(text, delimiter, -1);
+	}
+
+	/**
+     * 
+     * @return An error message as a result of unsuccessful validation;
+     * null if validation was successful.
+     */
+	public static String validateCsv(String text, String delimiter, int maxAmtOfRows) {
+		Scanner scanner = new Scanner(text);
+		List<String> lines = new ArrayList<String>();
+		while(scanner.hasNextLine()) {
+			String nextLine = scanner.nextLine();
+			if(StringUtils.isNotEmpty(nextLine) && !nextLine.startsWith("#")) {
+				lines.add(nextLine);
+			}
+		}
+		scanner.close();
+		
+		if(lines.size() < 2) {
+			return "Invalid CSV: must contain at least two rows";
+		}
+		if(maxAmtOfRows > 1 && lines.size() > maxAmtOfRows) {
+			return "Invalid CSV: may only contain a maximum of "+maxAmtOfRows+" rows";
+		}
+		for(int i = 1; i < lines.size(); i++) {
+			String line = lines.get(i);
+			if(!(line.split(delimiter).length == lines.get(0).split(delimiter).length)) {
+				return "Invalid CSV at row "+(i+1)+": all rows must contain an equal amount of comma-separated values";
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
=== Part 1: "local" variables ===

A new bit of functionality that allows users to A) set variables for individual reports and B) generate a set of clone reports with variables based on an input CSV.



=== Part 2: "external" variables ===

A new bit of functionality that allows users to refer to a previously run report's run-result for input data. Currently, it is only possible to extract data from valid XML messages. The syntax is as follows:
${report(relative path to target report)/checkpoint(index of target checkpoint)/xpath(xpath expression that points to the desired data)}

Example:

    ${report(../Pipeline HelloWorld)/checkpoint(3)/xpath(test/result)}

The user refers to the 'Pipeline HelloWorld' report in the parent folder...

    ${report(./Pipeline ManageDatabase)/checkpoint(3)/xpath(test/result)}

...then selects the report's third checkpoint, of which the index can be found in the checkpoint's path...

    ${report(./Pipeline ManageDatabase)/checkpoint(3)/xpath(test/result)}

...to then grab the value '1337' of that checkpoint's XML message, which would be "1337".