### PR TITLE
Decrease transformation textfield height

### DIFF
--- a/src/main/java/nl/nn/testtool/echo2/TransformationWindow.java
+++ b/src/main/java/nl/nn/testtool/echo2/TransformationWindow.java
@@ -36,7 +36,7 @@ import echopointng.tree.DefaultTreeCellRenderer;
  */
 public class TransformationWindow extends WindowPane implements ActionListener {
 	private static final long serialVersionUID = 1L;
-	public static final int TEXT_AREA_HEIGHT = 515;
+	public static final int TEXT_AREA_HEIGHT = 400;
 	private TextArea textArea;
 	private Label errorLabel;
 	private ReportXmlTransformer reportXmlTransformer = null;


### PR DESCRIPTION
When editing a report, it should now be possible to see all textfields and attributes without scrolling. (based on a default resolution of 1920x1080)