### PR TITLE
Simplify variable syntax

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,10 +6,11 @@ Ladybug Test Tool release notes
 Upcoming
 --------
 
+- Simplify syntax of cross-report variables
 
 
 
-2.0.12
+2.0.13
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,15 +9,7 @@ Upcoming
 
 
 
-2.0.14
----
-
-- Fix bug where pressing Replace on a report would cause an application error
-- Add a text field to the Clone window for editing the input message to clone
-- Make all of the Edit window's UI elements fit in one screen
-
-
-2.0.13
+2.0.12
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,15 @@ Upcoming
 
 
 
-2.0.12
+2.0.14
+---
+
+- Fix bug where pressing Replace on a report would cause an application error
+- Add a text field to the Clone window for editing the input message to clone
+- Make all of the Edit window's UI elements fit in one screen
+
+
+2.0.13
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import nl.nn.testtool.run.ReportRunner;
 import nl.nn.testtool.run.RunResult;
 import nl.nn.testtool.storage.StorageException;
+import nl.nn.testtool.util.ImportResult;
 import nl.nn.testtool.util.LogUtil;
 import nl.nn.testtool.util.XmlUtil;
 
@@ -56,12 +57,12 @@ public class Checkpoint implements Serializable, Cloneable {
 	private int stub = STUB_FOLLOW_REPORT_STRATEGY;
 	private int preTruncatedMessageLength = -1;
 	private long estimatedMemoryUsage = -1;
-	private transient static Pattern genericVariableCheckPattern;
+	private transient static Pattern genericVariablePattern;
 	private transient static Pattern externalVariablePattern;
 	private transient Map<String, Pattern> variablePatternMap;
 	static {
-		genericVariableCheckPattern = Pattern.compile("\\$\\{.*?\\}");
-		externalVariablePattern = Pattern.compile("\\$\\{report\\((.*?)\\)\\/checkpoint\\(([0-9]+)\\)\\/xpath\\((.*?)\\)\\}");
+		genericVariablePattern = Pattern.compile("\\$\\{.*?\\}");
+		externalVariablePattern = Pattern.compile("\\$\\{checkpoint\\(([0-9]+#[0-9]+)\\)(\\.xpath\\((.*?)\\)|)\\}");
 	}
 
 	public transient static final int TYPE_NONE = 0;
@@ -127,7 +128,7 @@ public class Checkpoint implements Serializable, Cloneable {
 
 	public void setMessage(String message) {
 		// report is null when called by XMLDecoder
-		if (report != null && report.getMessageTransformer() != null) {
+		if (report != null && report.getTestTool() != null && report.getMessageTransformer() != null) {
 			message = report.getMessageTransformer().transform(message);
 		}
 		this.message = message;
@@ -270,40 +271,19 @@ public class Checkpoint implements Serializable, Cloneable {
 					matchResults.add(m.toMatchResult());
 				}
 				for(MatchResult matchResult : matchResults) {
-					String relativeReportPath = matchResult.group(1);
-					int checkpointIndex = Integer.parseInt(matchResult.group(2));
-					String xpathExpression = matchResult.group(3);
+					int reportStorageId = Integer.parseInt(matchResult.group(1).split("#")[0]);
+					int checkpointIndex = Integer.parseInt(matchResult.group(1).split("#")[1]);
+					String xpathExpression = null;
+					if(StringUtils.isNotEmpty(matchResult.group(2))) {
+						xpathExpression = matchResult.group(3);
+					}
 					
 					// Determine the target report
-					String[] relativeReportPathSteps = relativeReportPath.split("/");
-					int[] operations = new int[relativeReportPathSteps.length];
-					for(int i = 0; i < relativeReportPathSteps.length; i++) {
-						String step = relativeReportPathSteps[i];
-						if(step.equals("..")) operations[i] = -1;
-						else if(step.equals(".")) operations[i] = 0;
-						else operations[i] = 1;
-					}
-					String determinedPath = report.getPath();
-					if(StringUtils.isEmpty(determinedPath)) determinedPath = "/";
-					String[] splitDeterminedPath = determinedPath.split("/");
-					for(int i = 0; i < operations.length; i++) {
-						switch(operations[i]) {
-							case -1:
-								if(determinedPath != "/") {
-									determinedPath = determinedPath.substring(0, determinedPath.length() - splitDeterminedPath[splitDeterminedPath.length-1].length()-1);
-								}
-								break;
-							case 1:
-								determinedPath += relativeReportPathSteps[i] + (i < operations.length-1? "/" : "");
-								break;
-						}
-					}
 					Report targetReport = null;
 					try {
 						for(Entry<Integer, RunResult> entry : reportRunner.getResults().entrySet()) {
-							if(determinedPath.equals(entry.getValue().fullPath)) {
+							if(entry.getKey() == reportStorageId) {
 								targetReport = reportRunner.getRunResultReport(entry.getValue().correlationId);
-								break;
 							}
 						}
 					} catch (StorageException e) {
@@ -312,32 +292,36 @@ public class Checkpoint implements Serializable, Cloneable {
 					// Attempt to fetch data from xpath in target checkpoint's XML message
 					if(targetReport != null) {
 						try {
-							String targetXml = targetReport.getCheckpoints().get(checkpointIndex).getMessage();
-							if(StringUtils.isNotEmpty(targetXml)) {
-								try {
-									String xpathResult = XmlUtil.createXPathEvaluator(xpathExpression).evaluate(targetXml);
-									if(xpathResult != null) {
-										try {
-											result = result.replaceAll(Pattern.quote(matchResult.group()), xpathResult);
-										} catch (IllegalArgumentException e) {
-											if(xpathResult.matches("\\$\\{.*?\\}")) {
-												log.warn(warningMessageHeader(matchResult.group())
-														+"Specified xpath expression points to incorrectly parsed parameter "+xpathResult+"; "
-														+ "see other recent log warnings for a possible cause");
+							String targetCheckpointMessage = targetReport.getCheckpoints().get(checkpointIndex).getMessage();
+							if(StringUtils.isNotEmpty(targetCheckpointMessage)) {
+								if(StringUtils.isNotEmpty(xpathExpression)) {
+									try {
+										String xpathResult = XmlUtil.createXPathEvaluator(xpathExpression).evaluate(targetCheckpointMessage);
+										if(xpathResult != null) {
+											try {
+												result = result.replace(matchResult.group(), xpathResult);
+											} catch (IllegalArgumentException e) {
+												if(genericVariablePattern.matcher(xpathResult).find()) {
+													log.warn(warningMessageHeader(matchResult.group())
+															+"Specified xpath expression points to incorrectly parsed parameter "+xpathResult+"; "
+															+ "see other recent log warnings for a possible cause");
+												}
 											}
 										}
+									} catch (XPathException e) {
+										log.warn(warningMessageHeader(matchResult.group())+"Invalid xpath expression or XML message in target checkpoint");
 									}
-								} catch (XPathException e) {
-									log.warn(warningMessageHeader(matchResult.group())+"Invalid xpath expression or XML message in target checkpoint");
+								} else {
+									result = result.replaceAll(Pattern.quote(matchResult.group()), targetCheckpointMessage);
 								}
 							} else {
 								log.warn(warningMessageHeader(matchResult.group())+"Target checkpoint ["+targetReport.getCheckpoints().get(checkpointIndex)+"] contains no message");
 							}
 						} catch (IndexOutOfBoundsException e) {
-							log.warn(warningMessageHeader(matchResult.group())+"Index out of bounds: checkpoint with index ["+checkpointIndex+"] does not exist in report ["+determinedPath+"]");
+							log.warn(warningMessageHeader(matchResult.group())+"Index out of bounds: checkpoint with index ["+checkpointIndex+"] does not exist in report with storageId ["+reportStorageId+"]");
 						}
 					} else {
-						log.warn(warningMessageHeader(matchResult.group())+"Run result not found for report ["+determinedPath+"] - please make sure it runs before this report");
+						log.warn(warningMessageHeader(matchResult.group())+"Run result not found for storageId ["+reportStorageId+"] - please make sure it runs before this report");
 					}
 				}
 			}
@@ -362,7 +346,7 @@ public class Checkpoint implements Serializable, Cloneable {
 	
 	public boolean containsVariables() {
 		if(StringUtils.isEmpty(getMessage())) return false;
-		return genericVariableCheckPattern.matcher(getMessage()).find();
+		return genericVariablePattern.matcher(getMessage()).find();
 	}
 
 	protected Map<String, Pattern> getVariablePatternMap(Map<String, String> variableMap) {
@@ -373,5 +357,34 @@ public class Checkpoint implements Serializable, Cloneable {
 			}
 		}
 		return variablePatternMap;
+	}
+
+	public String getIdentifier() {
+		return report.getStorageId()+"#"+report.getCheckpoints().indexOf(this);
+	}
+
+	/**
+	 * To be called when reports are uploaded to the Ladybug. Updates variables referring to 
+	 * a report that had its storageId changed.
+	 */
+	public boolean updateVariables(List<ImportResult> importResults) {
+		boolean isVariablesUpdated = false;
+		Matcher m = externalVariablePattern.matcher(getMessage());
+		List<MatchResult> matchResults = new ArrayList<MatchResult>();
+		while(m.find()) {
+			matchResults.add(m.toMatchResult());
+		}
+		for(MatchResult matchResult : matchResults) {
+			int matchResultStorageId = Integer.valueOf(matchResult.group(1).split("#")[0]);
+			for(ImportResult importResult : importResults) {
+				if(matchResultStorageId == importResult.getOldStorageId()) {
+					int newStorageId = importResult.getNewStorageId();
+					String newVar = matchResult.group().replaceAll(String.valueOf(matchResultStorageId), String.valueOf(newStorageId));
+					setMessage(getMessage().replace(matchResult.group(), newVar));
+					isVariablesUpdated = true;
+				}
+			}
+		}
+		return isVariablesUpdated;
 	}
 }

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -47,7 +47,9 @@ public class CheckpointComponent extends MessageComponent {
 	private RadioButton radioButtonStubOptionNo;
 	private Label messageHasBeenStubbedLabel;
 	private Label messageWasTruncatedLabel;
+	private Label reportStorageIdLabel;
 	private Label checkpointIndexLabel;
+	private Label checkpointUIDLabel;
 	private Label numberOfCharactersLabel;
 	private Label estimatedMemoryUsageLabel;
 
@@ -144,8 +146,19 @@ public class CheckpointComponent extends MessageComponent {
 		pathLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(pathLabel);
 		
+		reportStorageIdLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
+		add(reportStorageIdLabel);
+		
 		checkpointIndexLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(checkpointIndexLabel);
+		
+		checkpointUIDLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
+		checkpointUIDLabel.setToolTipText("A unique identifier consisting of the report's storageId "
+				+ "and this checkpoint's index. Use this value as part of a variable in another report's "
+				+ "input message to use this checkpoint's message as input. Example: ${checkpoint(287#13)}.\n\n"
+				+ "If this message is a valid XML message and you'd like to use a specific part of its data "
+				+ "instead, extend your variable to, for example, {checkpoint(287#13).xpath(results/result[1])}.");
+		add(checkpointUIDLabel);
 
 		numberOfCharactersLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(numberOfCharactersLabel);
@@ -198,7 +211,9 @@ public class CheckpointComponent extends MessageComponent {
 		threadNameLabel.setText("Thread name: " + checkpoint.getThreadName());
 		sourceClassNameLabel.setText("Source class name: " + checkpoint.getSourceClassName());
 		pathLabel.setText("Path: " + path);
+		reportStorageIdLabel.setText("Report storageId: "+report.getStorageId());
 		checkpointIndexLabel.setText("Checkpoint index: "+report.getCheckpoints().indexOf(checkpoint));
+		checkpointUIDLabel.setText("Checkpoint UID: "+checkpoint.getIdentifier());
 		numberOfCharactersLabel.setText("Number of characters: "+(checkpoint.getMessage() != null ? checkpoint.getMessage().length() : "0"));
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + checkpoint.getEstimatedMemoryUsage() + " bytes");
 		hideMessages();

--- a/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/ReportComponent.java
@@ -315,6 +315,8 @@ public class ReportComponent extends MessageComponent {
 		} else {
 			setMessage(reportXml);
 		}
+		messageTextArea.setVisible(false);
+		
 		storageIdLabel.setText("StorageId: " + report.getStorageId());
 		storageLabel.setText("Storage: " + report.getStorage().getName());
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + report.getEstimatedMemoryUsage() + " bytes");

--- a/src/main/java/nl/nn/testtool/echo2/util/Upload.java
+++ b/src/main/java/nl/nn/testtool/echo2/util/Upload.java
@@ -29,7 +29,7 @@ public class Upload {
 		if (filename.endsWith(".zip")) {
 			return Import.importZip(inputStream, storage, log);
 		} else if (filename.endsWith(".ttr")) {
-			return Import.importTtr(inputStream, storage, log);
+			return Import.importTtr(inputStream, storage, log).getErrorMessage();
 		} else {
 			return "File doesn't have a known file extension: " + filename;
 		}

--- a/src/main/java/nl/nn/testtool/run/ReportRunner.java
+++ b/src/main/java/nl/nn/testtool/run/ReportRunner.java
@@ -94,7 +94,6 @@ public class ReportRunner implements Runnable {
 		RunResult runResult = new RunResult();
 		runResult.correlationId = TestTool.getCorrelationId();
  		runResult.errorMessage = testTool.rerun(runResult.correlationId, report, securityContext, this);
- 		runResult.fullPath = report.getFullPath();
 		results.put(report.getStorageId(), runResult);
 	}
 

--- a/src/main/java/nl/nn/testtool/run/RunResult.java
+++ b/src/main/java/nl/nn/testtool/run/RunResult.java
@@ -21,5 +21,4 @@ package nl.nn.testtool.run;
 public class RunResult {
 	public String errorMessage;
 	public String correlationId;
-	public String fullPath;
 }

--- a/src/main/java/nl/nn/testtool/util/ImportResult.java
+++ b/src/main/java/nl/nn/testtool/util/ImportResult.java
@@ -1,0 +1,19 @@
+package nl.nn.testtool.util;
+
+public class ImportResult {
+	int oldStorageId;
+	int newStorageId;
+	String errorMessage;
+
+	public int getOldStorageId() {
+		return oldStorageId;
+	}
+	
+	public int getNewStorageId() {
+		return newStorageId;
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+}


### PR DESCRIPTION
=== 1. More simple variable syntax ===

Old vs new:
${report(./Pipeline HelloWorld)/checkpoint(23)/xpath(results/result[1])}
${checkpoint(287#23).xpath(results/result[1])}

Rather than having to copy a pipeline's name and building a relative path around it, users will now be able to skip that step and head straight to copying the checkpoint index (now checkpoint UID), which contains the report's storageId and the checkpoint's index.

Additionally, when uploading a zip-bundle of reports including some that interact with each other, the Ladybug will now automatically update the variables referring to those reports with their new storageId.

=== 2. Allow referring to entire checkpoint messages ===

If the user needs the value of a sessionKey or param, they can use ${checkpoint(287#23)}, leaving out the xpath part. This type of variable will be parsed to the entire checkpoint message.