### PR TITLE
Ignore XML headers when validating XPath for cross-report variables

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,15 +9,7 @@ Upcoming
 
 
 
-2.0.14
----
-
-- Fix bug where pressing Replace on a report would cause an application error
-- Add a text field to the Clone window for editing the input message to clone
-- Make all of the Edit window's UI elements fit in one screen
-
-
-2.0.13
+2.0.12
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,15 @@ Upcoming
 
 
 
-2.0.12
+2.0.14
+---
+
+- Fix bug where pressing Replace on a report would cause an application error
+- Add a text field to the Clone window for editing the input message to clone
+- Make all of the Edit window's UI elements fit in one screen
+
+
+2.0.13
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -59,10 +59,12 @@ public class Checkpoint implements Serializable, Cloneable {
 	private long estimatedMemoryUsage = -1;
 	private transient static Pattern genericVariablePattern;
 	private transient static Pattern externalVariablePattern;
+	private transient static Pattern xmlHeaderPattern;
 	private transient Map<String, Pattern> variablePatternMap;
 	static {
 		genericVariablePattern = Pattern.compile("\\$\\{.*?\\}");
 		externalVariablePattern = Pattern.compile("\\$\\{checkpoint\\(([0-9]+#[0-9]+)\\)(\\.xpath\\((.*?)\\)|)\\}");
+		xmlHeaderPattern = Pattern.compile("<\\?xml.*?>");
 	}
 
 	public transient static final int TYPE_NONE = 0;
@@ -293,6 +295,9 @@ public class Checkpoint implements Serializable, Cloneable {
 					if(targetReport != null) {
 						try {
 							String targetCheckpointMessage = targetReport.getCheckpoints().get(checkpointIndex).getMessage();
+							if(targetCheckpointMessage.startsWith("<?xml")) {
+								targetCheckpointMessage = xmlHeaderPattern.matcher(targetCheckpointMessage).replaceAll("").trim();
+							}
 							if(StringUtils.isNotEmpty(targetCheckpointMessage)) {
 								if(StringUtils.isNotEmpty(xpathExpression)) {
 									try {


### PR DESCRIPTION
The XPath validator we're using can't deal properly with XML headers, so I've made the Ladybug look for that in a checkpoint message and, if present, remove it from the validator's input.