### PR TITLE
Add test tab options

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@ Upcoming
 --------
 
 - Simplify syntax of cross-report variables
+- Add toggle options for showing storage and checkpoint IDs in the UI
 - Add timestamp to filename when downloading zipped reports
 
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,15 +9,7 @@ Upcoming
 
 
 
-2.0.14
----
-
-- Fix bug where pressing Replace on a report would cause an application error
-- Add a text field to the Clone window for editing the input message to clone
-- Make all of the Edit window's UI elements fit in one screen
-
-
-2.0.13
+2.0.12
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,15 @@ Upcoming
 
 
 
-2.0.12
+2.0.14
+---
+
+- Fix bug where pressing Replace on a report would cause an application error
+- Add a text field to the Clone window for editing the input message to clone
+- Make all of the Edit window's UI elements fit in one screen
+
+
+2.0.13
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -359,6 +359,10 @@ public class Checkpoint implements Serializable, Cloneable {
 		return variablePatternMap;
 	}
 
+	public int getIndex() {
+		return report.getCheckpoints().indexOf(this);
+	}
+
 	public String getIdentifier() {
 		return report.getStorageId()+"#"+report.getCheckpoints().indexOf(this);
 	}

--- a/src/main/java/nl/nn/testtool/Checkpoint.java
+++ b/src/main/java/nl/nn/testtool/Checkpoint.java
@@ -363,7 +363,7 @@ public class Checkpoint implements Serializable, Cloneable {
 		return report.getCheckpoints().indexOf(this);
 	}
 
-	public String getIdentifier() {
+	public String getUID() {
 		return report.getStorageId()+"#"+report.getCheckpoints().indexOf(this);
 	}
 

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -56,7 +56,6 @@ public class TestTool {
 	private MessageTransformer messageTransformer;
 	private List reportsToSkip = new ArrayList();
 	private String regexFilter;
-	private boolean showDetailedCheckpointMetadata = true;
 
 	public void setConfigName(String configName) {
 		this.configName = configName;
@@ -410,17 +409,5 @@ public class TestTool {
 
 	public static String getImplementationVersion() {
 		return Package.getPackage("nl.nn.testtool").getImplementationVersion();
-	}
-
-	public boolean isShowDetailedCheckpointMetadata() {
-		return showDetailedCheckpointMetadata;
-	}
-
-	public void setShowDetailedCheckpointMetadata(boolean showDetailedCheckpointMetadata) {
-		this.showDetailedCheckpointMetadata = showDetailedCheckpointMetadata;
-	}
-
-	public void toggleShowDetailedCheckpointMetadata() {
-		this.showDetailedCheckpointMetadata = !showDetailedCheckpointMetadata;
 	}
 }

--- a/src/main/java/nl/nn/testtool/TestTool.java
+++ b/src/main/java/nl/nn/testtool/TestTool.java
@@ -56,6 +56,7 @@ public class TestTool {
 	private MessageTransformer messageTransformer;
 	private List reportsToSkip = new ArrayList();
 	private String regexFilter;
+	private boolean showDetailedCheckpointMetadata = true;
 
 	public void setConfigName(String configName) {
 		this.configName = configName;
@@ -409,5 +410,17 @@ public class TestTool {
 
 	public static String getImplementationVersion() {
 		return Package.getPackage("nl.nn.testtool").getImplementationVersion();
+	}
+
+	public boolean isShowDetailedCheckpointMetadata() {
+		return showDetailedCheckpointMetadata;
+	}
+
+	public void setShowDetailedCheckpointMetadata(boolean showDetailedCheckpointMetadata) {
+		this.showDetailedCheckpointMetadata = showDetailedCheckpointMetadata;
+	}
+
+	public void toggleShowDetailedCheckpointMetadata() {
+		this.showDetailedCheckpointMetadata = !showDetailedCheckpointMetadata;
 	}
 }

--- a/src/main/java/nl/nn/testtool/echo2/Echo2Application.java
+++ b/src/main/java/nl/nn/testtool/echo2/Echo2Application.java
@@ -637,4 +637,8 @@ public class Echo2Application extends ApplicationInstance implements Application
 		}
 		return null;
 	}
+
+	public ReportsTreeCellRenderer getReportsTreeCellRenderer() {
+		return reportsTreeCellRenderer;
+	}
 }

--- a/src/main/java/nl/nn/testtool/echo2/RunPane.java
+++ b/src/main/java/nl/nn/testtool/echo2/RunPane.java
@@ -60,7 +60,7 @@ public class RunPane extends Tab implements BeanParent {
 
 		SplitPane splitPane1 = new SplitPane(SplitPane.ORIENTATION_HORIZONTAL);
 		splitPane1.setResizable(true);
-		splitPane1.setSeparatorPosition(new Extent(400, Extent.PX));
+		splitPane1.setSeparatorPosition(new Extent(280, Extent.PX));
 
 		// Wire
 

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -157,7 +157,7 @@ public class CheckpointComponent extends MessageComponent {
 				+ "and this checkpoint's index. Use this value as part of a variable in another report's "
 				+ "input message to use this checkpoint's message as input. Example: ${checkpoint(287#13)}.\n\n"
 				+ "If this message is a valid XML message and you'd like to use a specific part of its data "
-				+ "instead, extend your variable to, for example, {checkpoint(287#13).xpath(results/result[1])}.");
+				+ "instead, extend your variable to, for example, ${checkpoint(287#13).xpath(results/result[1])}.");
 		add(checkpointUIDLabel);
 
 		numberOfCharactersLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
@@ -212,7 +212,7 @@ public class CheckpointComponent extends MessageComponent {
 		sourceClassNameLabel.setText("Source class name: " + checkpoint.getSourceClassName());
 		pathLabel.setText("Path: " + path);
 		reportStorageIdLabel.setText("Report storageId: "+report.getStorageId());
-		checkpointIndexLabel.setText("Checkpoint index: "+report.getCheckpoints().indexOf(checkpoint));
+		checkpointIndexLabel.setText("Checkpoint index: "+checkpoint.getIndex());
 		checkpointUIDLabel.setText("Checkpoint UID: "+checkpoint.getIdentifier());
 		numberOfCharactersLabel.setText("Number of characters: "+(checkpoint.getMessage() != null ? checkpoint.getMessage().length() : "0"));
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + checkpoint.getEstimatedMemoryUsage() + " bytes");

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -47,8 +47,6 @@ public class CheckpointComponent extends MessageComponent {
 	private RadioButton radioButtonStubOptionNo;
 	private Label messageHasBeenStubbedLabel;
 	private Label messageWasTruncatedLabel;
-	private Label reportStorageIdLabel;
-	private Label checkpointIndexLabel;
 	private Label checkpointUIDLabel;
 	private Label numberOfCharactersLabel;
 	private Label estimatedMemoryUsageLabel;
@@ -146,12 +144,6 @@ public class CheckpointComponent extends MessageComponent {
 		pathLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		add(pathLabel);
 		
-		reportStorageIdLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
-		add(reportStorageIdLabel);
-		
-		checkpointIndexLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
-		add(checkpointIndexLabel);
-		
 		checkpointUIDLabel = Echo2Application.createInfoLabelWithColumnLayoutData();
 		checkpointUIDLabel.setToolTipText("A unique identifier consisting of the report's storageId "
 				+ "and this checkpoint's index. Use this value as part of a variable in another report's "
@@ -211,8 +203,6 @@ public class CheckpointComponent extends MessageComponent {
 		threadNameLabel.setText("Thread name: " + checkpoint.getThreadName());
 		sourceClassNameLabel.setText("Source class name: " + checkpoint.getSourceClassName());
 		pathLabel.setText("Path: " + path);
-		reportStorageIdLabel.setText("Report storageId: "+report.getStorageId());
-		checkpointIndexLabel.setText("Checkpoint index: "+checkpoint.getIndex());
 		checkpointUIDLabel.setText("Checkpoint UID: "+checkpoint.getUID());
 		numberOfCharactersLabel.setText("Number of characters: "+(checkpoint.getMessage() != null ? checkpoint.getMessage().length() : "0"));
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + checkpoint.getEstimatedMemoryUsage() + " bytes");

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -213,7 +213,7 @@ public class CheckpointComponent extends MessageComponent {
 		pathLabel.setText("Path: " + path);
 		reportStorageIdLabel.setText("Report storageId: "+report.getStorageId());
 		checkpointIndexLabel.setText("Checkpoint index: "+checkpoint.getIndex());
-		checkpointUIDLabel.setText("Checkpoint UID: "+checkpoint.getIdentifier());
+		checkpointUIDLabel.setText("Checkpoint UID: "+checkpoint.getUID());
 		numberOfCharactersLabel.setText("Number of characters: "+(checkpoint.getMessage() != null ? checkpoint.getMessage().length() : "0"));
 		estimatedMemoryUsageLabel.setText("EstimatedMemoryUsage: " + checkpoint.getEstimatedMemoryUsage() + " bytes");
 		hideMessages();
@@ -232,7 +232,7 @@ public class CheckpointComponent extends MessageComponent {
 		} else if (radioButtonStubOptionYes == e.getSource()) {
 			checkpoint.setStub(Checkpoint.STUB_YES);
 		} else if (e.getActionCommand().equals("Download")) {
-			if ("Both".equals(downloadSelectField.getSelectedItem())) {
+			if ("Report + Message".equals(downloadSelectField.getSelectedItem())) {
 				displayAndLogError(Download.download(report, checkpoint));
 			} else if ("Message".equals(downloadSelectField.getSelectedItem())) {
 				displayAndLogError(Download.download(checkpoint));

--- a/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/CheckpointComponent.java
@@ -232,7 +232,7 @@ public class CheckpointComponent extends MessageComponent {
 		} else if (radioButtonStubOptionYes == e.getSource()) {
 			checkpoint.setStub(Checkpoint.STUB_YES);
 		} else if (e.getActionCommand().equals("Download")) {
-			if ("Report + Message".equals(downloadSelectField.getSelectedItem())) {
+			if ("Both".equals(downloadSelectField.getSelectedItem())) {
 				displayAndLogError(Download.download(report, checkpoint));
 			} else if ("Message".equals(downloadSelectField.getSelectedItem())) {
 				displayAndLogError(Download.download(checkpoint));

--- a/src/main/java/nl/nn/testtool/echo2/reports/ReportsTreeCellRenderer.java
+++ b/src/main/java/nl/nn/testtool/echo2/reports/ReportsTreeCellRenderer.java
@@ -37,6 +37,7 @@ import nl.nn.testtool.util.LogUtil;
  */
 public class ReportsTreeCellRenderer extends DefaultTreeCellRenderer {
 	private Logger log = LogUtil.getLogger(this);
+	private boolean showReportAndCheckpointIds;
 
 	/**
 	 * http://echopoint.sourceforge.net/LinkedArticles/UsingtheTreeComponent.html Advanced Tree Rendering
@@ -51,6 +52,9 @@ public class ReportsTreeCellRenderer extends DefaultTreeCellRenderer {
 			if (userObject instanceof Report) {
 				label = super.getTreeCellRendererText(tree, node, selected, expanded, leaf);
 				Report report = (Report)userObject;
+				if(showReportAndCheckpointIds) {
+					label.setText("["+report.getStorageId()+"] "+report.getName());
+				}
 				if (report.getDifferenceChecked()) {
 					if (report.getDifferenceFound()) {
 						label.setForeground(Echo2Application.getDifferenceFoundLabelColor());
@@ -65,7 +69,11 @@ public class ReportsTreeCellRenderer extends DefaultTreeCellRenderer {
 				label = new Label();
 				label.setIconTextMargin(new Extent(0));
 				label.setFont(DefaultTreeCellRenderer.DEFAULT_FONT);
-				label.setText(checkpoint.getName());
+				if(showReportAndCheckpointIds) {
+					label.setText(checkpoint.getIndex()+". "+checkpoint.getName());
+				} else {
+					label.setText(checkpoint.getName());
+				}
 				if (checkpoint.getType() == Checkpoint.TYPE_STARTPOINT) {
 					if (defaultMutableTreeNode.getLevel() % 2 == 0) {
 						label.setIcon(new ResourceImageReference("/nl/nn/testtool/echo2/reports/startpoint-even.gif"));
@@ -137,5 +145,9 @@ public class ReportsTreeCellRenderer extends DefaultTreeCellRenderer {
 			}
 		}
 		return label;
+	}
+	
+	public void setShowReportAndCheckpointIds(boolean showReportAndCheckpointIds) {
+		this.showReportAndCheckpointIds = showReportAndCheckpointIds;
 	}
 }

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -194,6 +194,12 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		Echo2Application.decorateButton(resetSelectedButton);
 		buttonRow.add(resetSelectedButton);
 
+		Button prepareOptionsButton = new Button("Options...");
+		prepareOptionsButton.setActionCommand("OpenOptionsWindow");
+		Echo2Application.decorateButton(prepareOptionsButton);
+		prepareOptionsButton.addActionListener(this);
+		buttonRow.add(prepareOptionsButton);
+
 		Button selectAllButton = new Button("Select all");
 		selectAllButton.setActionCommand("SelectAll");
 		selectAllButton.addActionListener(this);
@@ -247,12 +253,6 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		Echo2Application.decorateButton(prepareUploadButton);
 		prepareUploadButton.addActionListener(this);
 		buttonRow.add(prepareUploadButton);
-
-		Button prepareOptionsButton = new Button("Options...");
-		prepareOptionsButton.setActionCommand("OpenOptionsWindow");
-		Echo2Application.decorateButton(prepareOptionsButton);
-		prepareOptionsButton.addActionListener(this);
-		buttonRow.add(prepareOptionsButton);
 
 		progressBar = new ProgressBar();
 		buttonRow.add(progressBar);
@@ -528,7 +528,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		Echo2Application.decorateButton(button);
 		row.add(button);
 		
-		Label label = new Label(String.valueOf(report.getStorageId())+".");
+		Label label = new Label(String.valueOf(report.getStorageId()));
 		label.setForeground(Echo2Application.getButtonBackgroundColor());
 		label.setVisible(showReportStorageIds);
 		row.add(label);

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -606,15 +606,24 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 				List<String> actionLabels = new ArrayList<String>();
 				List<String> actionCommands = new ArrayList<String>();
 				List<ActionListener> actionListeners = new ArrayList<ActionListener>();
-				actionLabels.add("Yes, delete all selected reports");
+				
+				int reportsSelected = getSelectedReportCount();
+				String popupMessage;
+				String confirmActionLabelText;
+				if(reportsSelected > 1) {
+					popupMessage = "Are you sure you want to delete the "+reportsSelected+" selected reports?";
+					confirmActionLabelText = "Yes, delete "+reportsSelected+" selected reports";
+				} else {
+					popupMessage = "Are you sure you want to delete the selected report?";
+					confirmActionLabelText = "Yes, delete 1 selected report";
+				}
+				
+				actionLabels.add(confirmActionLabelText);
 				actionCommands.add("DeleteOk");
 				actionListeners.add(this);
 				actionLabels.add("No, cancel this action");
 				actionCommands.add("DeleteCancel");
 				actionListeners.add(this);
-				int reportsSelected = getSelectedReportCount();
-				String popupMessage = reportsSelected > 1 ? "Are you sure you want to delete the "+reportsSelected+" selected reports?"
-						: "Are you sure you want to delete the selected report?";
 				PopupWindow popupWindow = new PopupWindow("", popupMessage, 450, 100,
 						actionLabels, actionCommands, actionListeners);
 				echo2Application.getContentPane().add(popupWindow);

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -84,6 +84,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private ReportXmlTransformer reportXmlTransformer = null;
 	private WindowPane uploadWindow;
 	private WindowPane reportGenerationWindow;
+	private WindowPane optionsWindow;
 	private UploadSelect uploadSelect;
 	private int numberOfComponentsToSkipForRowManipulation = 0;
 	private String lastDisplayedPath;
@@ -102,6 +103,8 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private TextArea cloneGenerationReportInputTextArea;
 	private Label cloneGenerationReportInputLabel;
 	
+	// options
+	private boolean showReportStorageIds;
 	public RunComponent() {
 		super();
 	}
@@ -133,6 +136,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		// TODO code voor aanmaken upload window en ander zaken gaan delen met ReportsComponent
 		Column uploadColumn = new Column();
 		Column cloneGenerationColumn = new Column();
+		Column optionsColumn = new Column();
 
 		uploadWindow = new WindowPane();
 		uploadWindow.setVisible(false);
@@ -148,8 +152,6 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		
 		reportGenerationWindow = new WindowPane();
 		reportGenerationWindow.setTitle("Generate report clones");
-//		reportGenerationWindow.setTitleBackground(Echo2Application.getButtonBackgroundColor());
-//		reportGenerationWindow.setBorder(new FillImageBorder(Echo2Application.getButtonBackgroundColor(), new Insets(0, 0, 0, 0), new Insets(0, 0, 0, 0)));
 		reportGenerationWindow.setVisible(false);
 		reportGenerationWindow.setWidth(new Extent(464));
 		reportGenerationWindow.setHeight(new Extent(610));
@@ -157,6 +159,16 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		reportGenerationWindow.add(cloneGenerationColumn);
 		reportGenerationWindow.setDefaultCloseOperation(WindowPane.HIDE_ON_CLOSE);
 		reportGenerationWindow.init();
+		
+		optionsWindow = new WindowPane();
+		optionsWindow.setTitle("Options");
+		optionsWindow.setVisible(false);
+		optionsWindow.setWidth(new Extent(480));
+		optionsWindow.setHeight(new Extent(120));
+		optionsWindow.setInsets(new Insets(5, 5, 5, 5));
+		optionsWindow.add(optionsColumn);
+		optionsWindow.setDefaultCloseOperation(WindowPane.HIDE_ON_CLOSE);
+		optionsWindow.init();
 
 		Row buttonRow = Echo2Application.getNewRow();
 
@@ -232,6 +244,12 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		prepareUploadButton.addActionListener(this);
 		buttonRow.add(prepareUploadButton);
 
+		Button prepareOptionsButton = new Button("Options...");
+		prepareOptionsButton.setActionCommand("OpenOptionsWindow");
+		Echo2Application.decorateButton(prepareOptionsButton);
+		prepareOptionsButton.addActionListener(this);
+		buttonRow.add(prepareOptionsButton);
+
 		progressBar = new ProgressBar();
 		buttonRow.add(progressBar);
 		reportRunner = new ReportRunner();
@@ -268,7 +286,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		uploadSelectRow.add(uploadSelect);
 		uploadColumn.add(uploadSelectRow);
 
-		// Report generation window		
+		// Report generation window
 		reportGenerationWarningLabel = Echo2Application.createErrorLabel();
 		reportGenerationWarningLabel.setVisible(false);
 		Row row = Echo2Application.getNewRow();
@@ -309,6 +327,16 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		row.add(generateClonesButton);
 		cloneGenerationColumn.add(row);
 		//
+		
+		// Options window
+		CheckBox showReportStorageIdsCheckbox = new CheckBox("Show report storage IDs");
+		showReportStorageIdsCheckbox.setActionCommand("ToggleReportStorageIds");
+		showReportStorageIdsCheckbox.addActionListener(this);
+		showReportStorageIdsCheckbox.setSelected(showReportStorageIds);
+		row = Echo2Application.getNewRow();
+		row.add(showReportStorageIdsCheckbox);
+		optionsColumn.add(row);
+		//
 
 		add(buttonRow);
 		numberOfComponentsToSkipForRowManipulation++;
@@ -331,6 +359,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		this.echo2Application = Echo2Application.getEcho2Application(beanParent, this);
 		echo2Application.getContentPane().add(uploadWindow);
 		echo2Application.getContentPane().add(reportGenerationWindow);
+		echo2Application.getContentPane().add(optionsWindow);
 		RunPane runPane = (RunPane)beanParent.getBeanParent();
 		treePane = runPane.getTreePane();
 		reportRunner.setSecurityContext(echo2Application);
@@ -477,8 +506,13 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		button.setVisible(false);
 		Echo2Application.decorateButton(button);
 		row.add(button);
+		
+		Label label = new Label("["+String.valueOf(report.getStorageId())+"]");
+		label.setForeground(Echo2Application.getButtonRolloverBackgroundColor());
+		label.setVisible(showReportStorageIds);
+		row.add(label);
 
-		Label label = new Label(path + name);
+		label = new Label(path + name);
 		row.add(label);
 		RunResult runResult = reportRunner.getResults().get(Integer.parseInt(storageId));
 		if (runResult != null) {
@@ -601,6 +635,12 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 			displayAndLogError(Download.download(runStorage));
 		} else if (e.getActionCommand().equals("OpenUploadWindow")) {
 			uploadWindow.setVisible(true);
+		} else if (e.getActionCommand().equals("OpenOptionsWindow")) {
+			System.out.println("Window should be visible now");
+			optionsWindow.setVisible(true);
+		} else if (e.getActionCommand().equals("ToggleReportStorageIds")) {
+			showReportStorageIds = !showReportStorageIds;
+			refresh();
 		} else if (e.getActionCommand().equals("DeleteSelected")) {
 			if (minimalOneSelected()) {
 				List<String> actionLabels = new ArrayList<String>();

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -104,7 +104,11 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private Label cloneGenerationReportInputLabel;
 	
 	// options
+	private CheckBox showReportStorageIdsCheckbox;
+	private CheckBox showCheckpointIdsCheckbox;
 	private boolean showReportStorageIds;
+	private boolean showCheckpointIds;
+	
 	public RunComponent() {
 		super();
 	}
@@ -163,7 +167,7 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		optionsWindow = new WindowPane();
 		optionsWindow.setTitle("Options");
 		optionsWindow.setVisible(false);
-		optionsWindow.setWidth(new Extent(480));
+		optionsWindow.setWidth(new Extent(280));
 		optionsWindow.setHeight(new Extent(120));
 		optionsWindow.setInsets(new Insets(5, 5, 5, 5));
 		optionsWindow.add(optionsColumn);
@@ -329,12 +333,29 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		//
 		
 		// Options window
-		CheckBox showReportStorageIdsCheckbox = new CheckBox("Show report storage IDs");
+		showReportStorageIdsCheckbox = new CheckBox("Show report storage IDs");
 		showReportStorageIdsCheckbox.setActionCommand("ToggleReportStorageIds");
 		showReportStorageIdsCheckbox.addActionListener(this);
 		showReportStorageIdsCheckbox.setSelected(showReportStorageIds);
+
+		showCheckpointIdsCheckbox = new CheckBox("Show checkpoint IDs");
+		showCheckpointIdsCheckbox.setActionCommand("ToggleCheckpointIds");
+		showCheckpointIdsCheckbox.addActionListener(this);
+		showCheckpointIdsCheckbox.setSelected(showCheckpointIds);
+		
+		Button restoreDefaultsButton = new Button("Restore defaults");
+		restoreDefaultsButton.setActionCommand("RestoreDefaults");
+		restoreDefaultsButton.addActionListener(this);
+		Echo2Application.decorateButton(restoreDefaultsButton);
+
 		row = Echo2Application.getNewRow();
 		row.add(showReportStorageIdsCheckbox);
+		optionsColumn.add(row);
+		row = Echo2Application.getNewRow();
+		row.add(showCheckpointIdsCheckbox);
+		optionsColumn.add(row);
+		row = Echo2Application.getNewRow();
+		row.add(restoreDefaultsButton);
 		optionsColumn.add(row);
 		//
 
@@ -507,8 +528,8 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		Echo2Application.decorateButton(button);
 		row.add(button);
 		
-		Label label = new Label("["+String.valueOf(report.getStorageId())+"]");
-		label.setForeground(Echo2Application.getButtonRolloverBackgroundColor());
+		Label label = new Label(String.valueOf(report.getStorageId())+".");
+		label.setForeground(Echo2Application.getButtonBackgroundColor());
 		label.setVisible(showReportStorageIds);
 		row.add(label);
 
@@ -636,10 +657,19 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 		} else if (e.getActionCommand().equals("OpenUploadWindow")) {
 			uploadWindow.setVisible(true);
 		} else if (e.getActionCommand().equals("OpenOptionsWindow")) {
-			System.out.println("Window should be visible now");
 			optionsWindow.setVisible(true);
 		} else if (e.getActionCommand().equals("ToggleReportStorageIds")) {
-			showReportStorageIds = !showReportStorageIds;
+			showReportStorageIds = showReportStorageIdsCheckbox.isSelected();
+			refresh();
+		} else if (e.getActionCommand().equals("ToggleCheckpointIds")) {
+			showCheckpointIds = showCheckpointIdsCheckbox.isSelected();
+			echo2Application.getReportsTreeCellRenderer().setShowReportAndCheckpointIds(showCheckpointIds);
+		} else if (e.getActionCommand().equals("RestoreDefaults")) {
+			showReportStorageIds = false;
+			showReportStorageIdsCheckbox.setSelected(false);
+			showCheckpointIds = false;
+			showCheckpointIdsCheckbox.setSelected(false);
+			echo2Application.getReportsTreeCellRenderer().setShowReportAndCheckpointIds(showCheckpointIds);
 			refresh();
 		} else if (e.getActionCommand().equals("DeleteSelected")) {
 			if (minimalOneSelected()) {


### PR DESCRIPTION
A new window opened with a new button that allows the user to enable/disable certain views in the Test tab. So far:

**[  ] Show report storage IDs**
Whether the reports' storage IDs should be shown in the Test tab.

![afbeelding](https://user-images.githubusercontent.com/28776293/77171687-21674280-6abd-11ea-8a36-39c15db3c61f.png)

**[  ] Show checkpoint IDs**
Whether checkpoints' names in the Report view's tree renderer should be preceded by their index.

![afbeelding](https://user-images.githubusercontent.com/28776293/77304783-3b8b6580-6cf5-11ea-9398-f6c7f41815d5.png)

With this last change, we can afford to remove the 'checkpoint index' attribute label, which has been found to be confusing. The 'report storageId' attribute label would also be redundant.