### PR TITLE
Fix run result visibility

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,15 +9,7 @@ Upcoming
 
 
 
-2.0.14
----
-
-- Fix bug where pressing Replace on a report would cause an application error
-- Add a text field to the Clone window for editing the input message to clone
-- Make all of the Edit window's UI elements fit in one screen
-
-
-2.0.13
+2.0.12
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,15 @@ Upcoming
 
 
 
-2.0.12
+2.0.14
+---
+
+- Fix bug where pressing Replace on a report would cause an application error
+- Add a text field to the Clone window for editing the input message to clone
+- Make all of the Edit window's UI elements fit in one screen
+
+
+2.0.13
 ---
 
 - Add functionality to declare and use ${variables} for reports

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -93,14 +93,14 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private TextArea cloneGenerationTextArea;
 	private Label reportGenerationWarningLabel;
 	
-	private int COMPONENT_CHECKBOX = 0;
-	private int COMPONENT_RUN_BUTTON = 1;
-	private int COMPONENT_OPEN_BUTTON = 2;
-	private int COMPONENT_COMPARE_BUTTON = 3;
-	private int COMPONENT_REPLACE_BUTTON = 4;
-	private int COMPONENT_STORAGEID_LABEL = 5;
-	private int COMPONENT_RESULT_LABEL = 6;
-	private int COMPONENT_DYNAMIC_VAR_LABEL = 7;
+	private final int COMPONENT_CHECKBOX = 0;
+	private final int COMPONENT_RUN_BUTTON = 1;
+	private final int COMPONENT_OPEN_BUTTON = 2;
+	private final int COMPONENT_COMPARE_BUTTON = 3;
+	private final int COMPONENT_REPLACE_BUTTON = 4;
+	private final int COMPONENT_STORAGEID_LABEL = 5;
+	private final int COMPONENT_RESULT_LABEL = 6;
+	private final int COMPONENT_DYNAMIC_VAR_LABEL = 7;
 	private TextArea cloneGenerationReportInputTextArea;
 	private Label cloneGenerationReportInputLabel;
 	

--- a/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
+++ b/src/main/java/nl/nn/testtool/echo2/run/RunComponent.java
@@ -98,8 +98,9 @@ public class RunComponent extends BaseComponent implements BeanParent, ActionLis
 	private int COMPONENT_OPEN_BUTTON = 2;
 	private int COMPONENT_COMPARE_BUTTON = 3;
 	private int COMPONENT_REPLACE_BUTTON = 4;
-	private int COMPONENT_RESULT_LABEL = 5;
-	private int COMPONENT_DYNAMIC_VAR_LABEL = 6;
+	private int COMPONENT_STORAGEID_LABEL = 5;
+	private int COMPONENT_RESULT_LABEL = 6;
+	private int COMPONENT_DYNAMIC_VAR_LABEL = 7;
 	private TextArea cloneGenerationReportInputTextArea;
 	private Label cloneGenerationReportInputLabel;
 	


### PR DESCRIPTION
The red/green result of a report run in the test tab currently updates the wrong label. This should fix that.