### PR TITLE
Refactoring XmlStorage to fix unnecessary rewrite

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,7 @@ Ladybug Test Tool release notes
 Upcoming
 --------
 
+- Refactor XmlStorage's MetadataHandler in order to minimize rewrites.
 - Fix metadata file format for XmlStorage
 - Improve storage id handling of XmlStorage while reading from a filesystem.
 - Fix report discovery for XmlStorage

--- a/src/main/java/nl/nn/testtool/storage/xml/Metadata.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/Metadata.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 WeAreFrank!
+   Copyright 2020-2021 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/main/java/nl/nn/testtool/storage/xml/Metadata.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/Metadata.java
@@ -93,8 +93,9 @@ public class Metadata {
 	/**
 	 * Creates a metadata object from the given report and storage id.
 	 *
-	 * @param report    Report to be used for creating a metadata.
-	 * @param lastModified Last modified time for the report file.
+	 * @param report Report to be used for creating a metadata.
+	 * @param file File of the report.
+	 * @param root Directory to relativize the path from.
 	 * @return Metadata object that is created from the given report.
 	 */
 	public static Metadata fromReport(Report report, File file, File root) {

--- a/src/main/java/nl/nn/testtool/storage/xml/Metadata.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/Metadata.java
@@ -21,6 +21,7 @@ import nl.nn.testtool.Report;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 
+import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -96,12 +97,25 @@ public class Metadata {
 	 * @param lastModified Last modified time for the report file.
 	 * @return Metadata object that is created from the given report.
 	 */
-	public static Metadata fromReport(Report report, long lastModified) {
+	public static Metadata fromReport(Report report, File file, File root) {
 		String status = "Success";
 		if (report.getCheckpoints() != null && report.getCheckpoints().size() > 0) {
 			if (report.getCheckpoints().get(report.getCheckpoints().size() - 1).getType() == Checkpoint.TYPE_ABORTPOINT)
 				status = "Error";
 		}
+
+		String path = root.toPath().relativize(file.getParentFile().toPath()).toString() + "/";
+		if (StringUtils.isNotEmpty(path)) {
+			path = path.replaceAll("\\\\", "/");
+			if (!path.endsWith("/"))
+				path += "/";
+		}
+		if (!path.startsWith("/"))
+			path = "/" + path;
+
+		String filename = file.getName();
+		filename = filename.substring(0, filename.length() - XmlStorage.FILE_EXTENSION.length());
+
 		return new Metadata(
 				report.getStorageId(),
 				report.getEndTime() - report.getStartTime(),
@@ -109,12 +123,12 @@ public class Metadata {
 				report.getEstimatedMemoryUsage(),
 				report.getStorageSize() != null ? report.getStorageSize() : 0L,
 				report.getEndTime(),
-				report.getName(),
+				filename,
 				report.getCorrelationId(),
 				status,
-				report.getPath(),
+				path,
 				report.getDescription(),
-				lastModified);
+				file.lastModified());
 	}
 
 	public static Metadata fromXml(String xml) {

--- a/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
@@ -17,14 +17,11 @@ package nl.nn.testtool.storage.xml;
 
 import nl.nn.testtool.Report;
 import nl.nn.testtool.storage.StorageException;
-import nl.nn.xmldecoder.XMLDecoder;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -93,9 +90,13 @@ public class MetadataHandler {
 				buildFromDirectory(file, true);
 
 			if (file.isFile() && file.getName().endsWith(XmlStorage.FILE_EXTENSION)) {
-				Report report = importFromFile(file, false, false);
-				HashMap<File, Report> reportsForStorageId = reports.computeIfAbsent(report.getStorageId(), k -> new HashMap<>());
-				reportsForStorageId.put(file, report);
+				try {
+					Report report = storage.readReportFromFile(file);
+					HashMap<File, Report> reportsForStorageId = reports.computeIfAbsent(report.getStorageId(), k -> new HashMap<>());
+					reportsForStorageId.put(file, report);
+				} catch (StorageException exception) {
+					logger.warn("Exception while reading report [" + file.getPath() + "] during build from directory.");
+				}
 			}
 		}
 		// For each storage id, add reports to metadataMap.
@@ -357,82 +358,24 @@ public class MetadataHandler {
 			String path = "/" + storage.getReportsFolder().toPath().relativize(file.toPath()).toString().replaceAll("\\\\", "/"); // Relativize
 			Metadata m = map.remove(path);
 			if (m == null || m.lastModified < file.lastModified()) {
-				Report report = importFromFile(file, true, true);
-				if (report == null) {
-					map.put(path, m);
-					continue;
-				}
 				try {
+					Report report = storage.readReportFromFile(file);
+					if (report == null) {
+						map.put(path, m);
+						continue;
+					}
+					// Todo: storage id update.
 					if (m == null || !(m.path.equalsIgnoreCase(report.getPath()) && m.storageId == report.getStorageId()))
 						storage.store(report, file);
 
 					Metadata metadata = Metadata.fromReport(report, file, storage.getReportsFolder());
 					add(metadata, false);
+					updatedIds.add(report.getStorageId());
 				} catch (StorageException | IOException e) {
 					logger.error("Error while updating metadata from file [" + file.getPath() + "]", e);
 				}
-				if (report != null)
-					updatedIds.add(report.getStorageId());
 			}
 		}
 		return updatedIds;
-	}
-
-	/**
-	 * Reads the report from the given file. Generates metadata and returns it.
-	 *
-	 * @param file File to be read from.
-	 * @param update True, if the goal of import is to update. In this case file will be compared to the cached metadata.
-	 * @param setMetadata True if report's storageId should be changed in case of conflicts.
-	 * @return Report generated from the given file.
-	 */
-	private Report importFromFile(File file, boolean update, boolean setMetadata) {
-		if (file == null || !file.isFile() || !file.getName().endsWith(XmlStorage.FILE_EXTENSION))
-			return null;
-
-		logger.debug("Adding from a new file: " + file.getPath());
-		FileInputStream inputStream = null;
-		XMLDecoder decoder = null;
-		try {
-			inputStream = new FileInputStream(file);
-			decoder = new XMLDecoder(new BufferedInputStream(inputStream));
-
-			Report report = (Report) decoder.readObject();
-			report.setStorage(this.storage);
-
-			int storageId = report.getStorageId() == 0 ? getNextStorageId() : report.getStorageId();
-			if (metadataMap.containsKey(storageId) && update) {
-				String oldpath = storage.resolvePath(storageId);
-				if (StringUtils.isNotEmpty(oldpath) && !oldpath.equalsIgnoreCase(file.getPath())) {
-					Report oldReport = importFromFile(new File(oldpath), false, false);
-					setMetadata = oldReport != null && report.getStorageId().equals(oldReport.getStorageId());
-				} else {
-					setMetadata = false;
-				}
-			}
-			if (setMetadata) {
-				while (metadataMap.containsKey(storageId))
-					storageId = getNextStorageId();
-
-				if (storageId >= lastStorageId)
-					lastStorageId = storageId + 1;
-
-				report.setStorageId(storageId);
-			}
-			return report;
-		} catch (Exception e) {
-			logger.error("Exception during report deserialization.", e);
-			if (decoder != null)
-				decoder.close();
-			if (inputStream != null) {
-				try {
-					inputStream.close();
-				} catch (Exception ignored) {
-					logger.error("Could not close the xml file.", ignored);
-				}
-			}
-		}
-		return null;
-
 	}
 }

--- a/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 WeAreFrank!
+   Copyright 2020-2021 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
@@ -377,7 +377,6 @@ public class MetadataHandler {
 
 								if (storageId >= lastStorageId)
 									lastStorageId = storageId + 1;
-								System.err.println(" ---- Rewriting report!! " + file.getPath());
 								report.setStorageId(storageId);
 								storage.store(report, file);
 							}

--- a/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/MetadataHandler.java
@@ -119,7 +119,7 @@ public class MetadataHandler {
 				try {
 					if (originalStorageIdTaken)
 						storage.store(report, file);
-					Metadata metadata = Metadata.fromReport(report, file.lastModified());
+					Metadata metadata = Metadata.fromReport(report, file, storage.getReportsFolder());
 					add(metadata, false);
 				} catch (StorageException | IOException e) {
 					logger.error("Error while updating metadata from file [" + file.getPath() + "]", e);
@@ -366,7 +366,7 @@ public class MetadataHandler {
 					if (m == null || !(m.path.equalsIgnoreCase(report.getPath()) && m.storageId == report.getStorageId()))
 						storage.store(report, file);
 
-					Metadata metadata = Metadata.fromReport(report, file.lastModified());
+					Metadata metadata = Metadata.fromReport(report, file, storage.getReportsFolder());
 					add(metadata, false);
 				} catch (StorageException | IOException e) {
 					logger.error("Error while updating metadata from file [" + file.getPath() + "]", e);
@@ -399,19 +399,6 @@ public class MetadataHandler {
 
 			Report report = (Report) decoder.readObject();
 			report.setStorage(this.storage);
-
-			String path = storage.getReportsFolder().toPath().relativize(file.getParentFile().toPath()).toString() + "/";
-			if (StringUtils.isNotEmpty(path)) {
-				path = path.replaceAll("\\\\", "/");
-				if (!path.endsWith("/"))
-					path += "/";
-			}
-			if (!path.startsWith("/"))
-				path = "/" + path;
-			report.setPath(path);
-
-			String filename = file.getName();
-			report.setName(filename.substring(0, filename.length() - XmlStorage.FILE_EXTENSION.length()));
 
 			int storageId = report.getStorageId() == 0 ? getNextStorageId() : report.getStorageId();
 			if (metadataMap.containsKey(storageId) && update) {

--- a/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 WeAreFrank!
+   Copyright 2020-2021 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
@@ -15,6 +15,14 @@
 */
 package nl.nn.testtool.storage.xml;
 
+import nl.nn.testtool.Report;
+import nl.nn.testtool.storage.CrudStorage;
+import nl.nn.testtool.storage.StorageException;
+import nl.nn.testtool.util.SearchUtil;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.BufferedInputStream;
@@ -25,15 +33,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import nl.nn.testtool.Report;
-import nl.nn.testtool.storage.CrudStorage;
-import nl.nn.testtool.storage.StorageException;
-import nl.nn.testtool.util.SearchUtil;
 
 /**
  * Handles report storage for ladybug.
@@ -142,7 +141,7 @@ public class XmlStorage implements CrudStorage {
 			}
 
 			store(report, reportFile);
-			metadata = Metadata.fromReport(report, reportFile.lastModified());
+			metadata = Metadata.fromReport(report, reportFile, reportsFolder);
 			metadataHandler.add(metadata);
 
 		} catch (IOException e) {

--- a/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
@@ -294,6 +294,44 @@ public class XmlStorage implements CrudStorage {
 	}
 
 	/**
+	 * Reads the report from the given file. Generates metadata and returns it.
+	 *
+	 * @param file File to be read from.
+	 * @return Report generated from the given file.
+	 */
+	protected Report readReportFromFile(File file) {
+		if (file == null || !file.isFile() || !file.getName().endsWith(XmlStorage.FILE_EXTENSION))
+			return null;
+
+		logger.debug("Adding from a new file: " + file.getPath());
+		FileInputStream inputStream = null;
+		XMLDecoder decoder = null;
+		Report report = null;
+		try {
+			inputStream = new FileInputStream(file);
+			decoder = new XMLDecoder(new BufferedInputStream(inputStream));
+
+			report = (Report) decoder.readObject();
+			report.setStorage(this);
+
+			decoder.close();
+			inputStream.close();
+		} catch (Exception e) {
+			logger.error("Exception during report deserialization.", e);
+			if (decoder != null)
+				decoder.close();
+			if (inputStream != null) {
+				try {
+					inputStream.close();
+				} catch (Exception ignored) {
+					logger.error("Could not close the xml file.", ignored);
+				}
+			}
+		}
+		return report;
+	}
+
+	/**
 	 * Resolves the path of the report with given storage Id
 	 *
 	 * @param storageId Storage Id of the report to be resolved.

--- a/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
+++ b/src/main/java/nl/nn/testtool/storage/xml/XmlStorage.java
@@ -271,7 +271,7 @@ public class XmlStorage implements CrudStorage {
 	}
 
 	/**
-	 * Reads the report from the given file. Generates metadata and returns it.
+	 * Reads the report from the given file.
 	 *
 	 * @param file File to be read from.
 	 * @return Report generated from the given file.


### PR DESCRIPTION
 - Simplifies MetadataHandler.importFromFile and move it to XmlStorage.readReportFromFile.
 - Adapt Metadata.fromReport to use path, name and lastmodified from given files.