### PR TITLE
API: Send out refined objects instead of String[] for metadata call

### DIFF
--- a/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/MetadataApi.java
@@ -52,102 +52,49 @@ public class MetadataApi extends ApiBase {
 	 * @param storageParam Name of the storage to search.
 	 * @param limit Maximum number of results to return.
 	 * @param uriInfo Query parameters for search.
-	 * @param sortParam Name of the sort to apply.
-	 * @param order The order, either ascending or descending.
 	 * @return Response containing fields [List[String]] and values [List[List[Object]]].
 	 * @throws ApiException If an exception occurs during metadata search in storage.
 	 */
 	@GET
 	@Path("/{storage}/")
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response getMetadataList(@PathParam("storage") String storageParam, @DefaultValue("-1") @QueryParam("limit") int limit ,
-									@DefaultValue("") @QueryParam("sort") String sortParam , @DefaultValue("Descending") @QueryParam("order") String order,
+	public Response getMetadataList(@PathParam("storage") String storageParam,
+									@DefaultValue("-1") @QueryParam("limit") int limit ,
+									@DefaultValue(".*") @QueryParam("filter") String filterParam ,
 									@Context UriInfo uriInfo) throws ApiException {
-		// TODO: Sorting and filtering
-		MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
-
-		// Make sure limit will not be included in searh parameters.
-		if (params != null) {
-			for (String p : new String[]{"limit", "sort", "order"})
-				params.remove(p);
-		}
 
 		List<String> searchValues = new ArrayList<>();
 		List<String> metadataNames = new ArrayList<>();
 		Set<String> storedMetadataFields = getMetadataFields();
-		int sort = -1;
-		int index = 0;
-		if (params == null || params.size() == 0) {
-			// Add all metadata fields to be extracted without filtering.
-			for(String field : storedMetadataFields) {
-				if (field.equalsIgnoreCase(sortParam)) sort = index;
-				index ++;
-				metadataNames.add(field);
+		for(String field : storedMetadataFields) {
+			metadataNames.add(field);
+			if ("name".equals(field)) {
+				searchValues.add("(" + filterParam + ")");
+			} else {
 				searchValues.add(null);
-			}
-		} else {
-			for (String param : params.keySet()) {
-				// Extract search parameters for storage from the query parameters.
-				if (param.equalsIgnoreCase(sortParam)) sort = index;
-				index ++;
-
-				List<String> values = params.get(param);
-				metadataNames.add(param);
-
-				if (values != null && values.size() > 0)
-					searchValues.add(values.get(0));
-				else
-					searchValues.add(null);
-
 			}
 		}
 		try {
 			// Get storage, search for metadata, and return the results.
-			Storage storage = null;
+			Storage storage;
 			if ("debugStorage".equals(storageParam)) {
 				storage = testTool.getDebugStorage();
 			} else if ("testStorage".equals(storageParam)) {
 				storage = testTool.getTestStorage();
-			}
-			List<List<Object>> list;
-
-			if (sort != -1) {
-				// Sort based on one of the fields.
-				list = storage.getMetadata(-1, metadataNames, searchValues, MetadataExtractor.VALUE_TYPE_OBJECT);
-
-				// Get the class of the field to check if it implements Comparable.
-				if (list.isEmpty()) return Response.noContent().build();
-				Class clazz = list.get(0).get(sort).getClass();
-
-				if (Comparable.class.isAssignableFrom(clazz)) {
-					// Sort the metadata.
-					Class<? extends Comparable> clazz2 = (Class<? extends Comparable>) clazz;
-					int finalSort = sort;
-					int finalOrder = order.equalsIgnoreCase("ascending") || order.equalsIgnoreCase("asc") ? 1 : -1;
-					list.sort((o1, o2) -> clazz2.cast(o1.get(finalSort)).compareTo(clazz2.cast(o2.get(finalSort))) * finalOrder);
-				}
-
-				// Limit the output list and serialize into String.
-				limit = limit > 0 ? Math.min(limit, list.size()) : list.size();
-				ArrayList<List<Object>> outList = new ArrayList<>(limit);
-				MetadataExtractor metadataExtractor = new MetadataExtractor();
-				for (int i = 0; i < limit; i++) {
-					List<Object> row = list.get(i);
-					String[] stringRow = new String[row.size()];
-					for (int j = 0; j < stringRow.length; j++) {
-						stringRow[j] = metadataExtractor.fromObjectToString(metadataNames.get(j), row.get(j));
-					}
-					outList.add(Arrays.asList(stringRow));
-				}
-				list = outList;
 			} else {
-				// Return unsorted.
-				list = storage.getMetadata(limit, metadataNames, searchValues, MetadataExtractor.VALUE_TYPE_STRING);
+				throw new StorageException("Storage param given is invalid, should be [debugStorage] or [testStorage]");
 			}
-			Map<String, Object> out = new HashMap<>(2);
-			out.put("fields", metadataNames);
-			out.put("values", list);
-			return Response.ok().entity(out).build();
+			List<List<Object>> list = storage.getMetadata(limit, metadataNames, searchValues, MetadataExtractor.VALUE_TYPE_STRING);
+			List<Map<String, String>> metadata = new ArrayList<>();
+			for (List<Object> item : list) {
+				Map<String, String> metadataItem = new HashMap<>();
+				for (int i = 0; i < metadataNames.size(); i++) {
+					metadataItem.put(metadataNames.get(i), item.get(i).toString());
+				}
+				metadata.add(metadataItem);
+			}
+
+			return Response.ok().entity(metadata).build();
 		} catch (StorageException e) {
 			throw new ApiException("Exception during filtering metadata.", e);
 		}


### PR DESCRIPTION
The API call for metadata used to send String[], but it is now changed to objects which is more clear and neat. The report filter has also been fixed now.