### PR TITLE
Change the way report and result is returned by the API

### DIFF
--- a/src/main/java/nl/nn/testtool/web/api/ReportApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/ReportApi.java
@@ -72,7 +72,7 @@ public class ReportApi extends ApiBase {
 			if (report == null)
 				return Response.status(Response.Status.NOT_FOUND).entity("Could not find report with id [" + storageId + "]").build();
 			if (xml) {
-				if (globalTransformer) {
+				if (globalTransformer || "testStorage".equals(storageParam) ) {
 					ReportXmlTransformer reportXmlTransformer = getBean("reportXmlTransformer");
 					if (reportXmlTransformer != null)
 						report.setGlobalReportXmlTransformer(reportXmlTransformer);

--- a/src/main/java/nl/nn/testtool/web/api/ReportApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/ReportApi.java
@@ -152,7 +152,6 @@ public class ReportApi extends ApiBase {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response updateReport(@PathParam("storage") String storageParam, @PathParam("storageId") int storageId, Map<String, String> map) {
 		String[] fields = new String[]{"name", "path", "variables", "description", "transformation", "checkpointId", "checkpointMessage"};
-		System.out.println(map);
 		if (map.isEmpty() || !mapContainsOnly(map, null, fields))
 			return Response.status(Response.Status.BAD_REQUEST).entity("No new values have been given for report with storageId [" + storageId + "]").build();
 

--- a/src/main/java/nl/nn/testtool/web/api/ReportApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/ReportApi.java
@@ -71,18 +71,19 @@ public class ReportApi extends ApiBase {
 			Report report = getReport(storage, storageId);
 			if (report == null)
 				return Response.status(Response.Status.NOT_FOUND).entity("Could not find report with id [" + storageId + "]").build();
-			if (xml) {
-				if (globalTransformer || "testStorage".equals(storageParam) ) {
-					ReportXmlTransformer reportXmlTransformer = getBean("reportXmlTransformer");
-					if (reportXmlTransformer != null)
-						report.setGlobalReportXmlTransformer(reportXmlTransformer);
-				}
-				HashMap<String, String> map = new HashMap<>(1);
-				map.put("xml", report.toXml());
-				return Response.ok(map).build();
-			} else {
-				return Response.ok().entity(report).build();
+
+			if (globalTransformer) {
+				ReportXmlTransformer reportXmlTransformer = getBean("reportXmlTransformer");
+				if (reportXmlTransformer != null)
+					report.setGlobalReportXmlTransformer(reportXmlTransformer);
 			}
+
+			HashMap<String, Object> map = new HashMap<>(1);
+			map.put("report", report);
+			map.put("xml", report.toXml());
+
+			return Response.ok(map).build();
+
 		} catch (Exception e) {
 			return Response.status(Response.Status.NOT_FOUND).entity("Exception while getting report [" + storageId + "] from storage [" + storageParam + "] :: " + e + Arrays.toString(e.getStackTrace())).build();
 		}

--- a/src/main/java/nl/nn/testtool/web/api/RunApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/RunApi.java
@@ -22,6 +22,7 @@ import nl.nn.testtool.run.RunResult;
 import nl.nn.testtool.storage.CrudStorage;
 import nl.nn.testtool.storage.Storage;
 import nl.nn.testtool.storage.StorageException;
+import nl.nn.testtool.transform.ReportXmlTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,13 +129,23 @@ public class RunApi extends ApiBase {
 						}
 					}
 
-					res.put("report", runResultReport);
 					res.put("stubbed", stubbed);
 					res.put("total", runResultReport.getCheckpoints().size() - 1);
 
 					Report report = reranReports.get(entry.getKey());
 					res.put("previousTime", report.getEndTime() - report.getStartTime());
 					res.put("currentTime", runResultReport.getEndTime() - runResultReport.getStartTime());
+
+					ReportXmlTransformer reportXmlTransformer = getBean("reportXmlTransformer");
+					report.setGlobalReportXmlTransformer(reportXmlTransformer);
+					runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
+
+					res.put("equal", report.toXml(runner).equals(runResultReport.toXml(runner)));
+					res.put("originalReport", report);
+					res.put("editedReport", runResultReport);
+					res.put("originalXml", report.toXml(runner));
+					res.put("editedXml", runResultReport.toXml(runner));
+
 				} catch (StorageException exception) {
 					res.put("exception", exception);
 					exception.printStackTrace();

--- a/src/main/java/nl/nn/testtool/web/api/RunApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/RunApi.java
@@ -142,9 +142,9 @@ public class RunApi extends ApiBase {
 
 					res.put("equal", report.toXml(runner).equals(runResultReport.toXml(runner)));
 					res.put("originalReport", report);
-					res.put("editedReport", runResultReport);
+					res.put("runResultReport", runResultReport);
 					res.put("originalXml", report.toXml(runner));
-					res.put("editedXml", runResultReport.toXml(runner));
+					res.put("runResultXml", runResultReport.toXml(runner));
 
 				} catch (StorageException exception) {
 					res.put("exception", exception);


### PR DESCRIPTION
 - The report also sends out XML so it can be combined.
 - The result returns the original and the edited report (and their respective XML). It also sends whether the reportXML's are equal.