### PR TITLE
Add ability to change the strategy of node linking

### DIFF
--- a/src/main/java/nl/nn/testtool/filter/View.java
+++ b/src/main/java/nl/nn/testtool/filter/View.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020, 2022 WeAreFrank!, 2018, 2019 Nationale-Nederlanden
+   Copyright 2020, 2022-2023 WeAreFrank!, 2018, 2019 Nationale-Nederlanden
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import nl.nn.testtool.storage.LogStorage;
 @Dependent
 public class View implements BeanParent {
 	protected String name;
+	protected String nodeLinkStrategy;
 	private @Setter @Getter @Inject @Autowired LogStorage debugStorage;
 	private @Setter @Getter @Inject @Autowired List<String> metadataNames;
 	private Map<String, String> metadataFilter;
@@ -45,12 +46,29 @@ public class View implements BeanParent {
 	private BeanParent beanParent;
 	private Echo2Application echo2Application;
 
+	protected enum NodeLinkStrategy {
+		PATH,
+		CHECKPOINT_NUMBER,
+		NONE
+	}
+
 	public void setName(String name) {
 		this.name = name;
 	}
 
 	public String getName() {
 		return name;
+	}
+
+	public void setNodeLinkStrategy(String nodeLinkStrategy) {
+		this.nodeLinkStrategy = nodeLinkStrategy;
+	}
+
+	public String getNodeLinkStrategy() {
+		if (nodeLinkStrategy == null) {
+			return NodeLinkStrategy.PATH.toString();
+		}
+		return nodeLinkStrategy;
 	}
 
 	public void setMetadataFilter(Map<String, String> metadataFilter) {

--- a/src/main/java/nl/nn/testtool/storage/proofofmigration/ProofOfMigrationView.java
+++ b/src/main/java/nl/nn/testtool/storage/proofofmigration/ProofOfMigrationView.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -46,5 +46,13 @@ public class ProofOfMigrationView extends View {
 	@Override
 	public List<String> getMetadataNames() {
 		return proofOfMigrationStorage.getMetadataNames();
+	}
+
+	@Override
+	public String getNodeLinkStrategy() {
+		if (nodeLinkStrategy == null) {
+			return NodeLinkStrategy.CHECKPOINT_NUMBER.toString();
+		}
+		return nodeLinkStrategy;
 	}
 }

--- a/src/main/java/nl/nn/testtool/web/ApiAuthorizationFilter.java
+++ b/src/main/java/nl/nn/testtool/web/ApiAuthorizationFilter.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 WeAreFrank!
+   Copyright 2021-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@ public class ApiAuthorizationFilter implements ContainerRequestFilter {
 		if (constructorDone) log.info("Set observer roles");
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/testtool.*$", observerRoles);
 		addConfigurationPart("POST/" + ApiServlet.LADYBUG_API_PATH + "/testtool/transformation[/]?$", observerRoles); // [/]? because frontend is currently not using a slash at the end
+		addConfigurationPart("PUT/"  + ApiServlet.LADYBUG_API_PATH + "/testtool/views/.*$", observerRoles);
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/metadata/.*$", observerRoles);
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/report/.*$", observerRoles);
 	}

--- a/src/main/java/nl/nn/testtool/web/ApiAuthorizationFilter.java
+++ b/src/main/java/nl/nn/testtool/web/ApiAuthorizationFilter.java
@@ -89,7 +89,7 @@ public class ApiAuthorizationFilter implements ContainerRequestFilter {
 		if (constructorDone) log.info("Set observer roles");
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/testtool.*$", observerRoles);
 		addConfigurationPart("POST/" + ApiServlet.LADYBUG_API_PATH + "/testtool/transformation[/]?$", observerRoles); // [/]? because frontend is currently not using a slash at the end
-		addConfigurationPart("PUT/"  + ApiServlet.LADYBUG_API_PATH + "/testtool/views/node-link-strategy$", observerRoles);
+		addConfigurationPart("PUT/"  + ApiServlet.LADYBUG_API_PATH + "/testtool/node-link-strategy$", observerRoles);
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/metadata/.*$", observerRoles);
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/report/.*$", observerRoles);
 	}

--- a/src/main/java/nl/nn/testtool/web/ApiAuthorizationFilter.java
+++ b/src/main/java/nl/nn/testtool/web/ApiAuthorizationFilter.java
@@ -89,7 +89,7 @@ public class ApiAuthorizationFilter implements ContainerRequestFilter {
 		if (constructorDone) log.info("Set observer roles");
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/testtool.*$", observerRoles);
 		addConfigurationPart("POST/" + ApiServlet.LADYBUG_API_PATH + "/testtool/transformation[/]?$", observerRoles); // [/]? because frontend is currently not using a slash at the end
-		addConfigurationPart("PUT/"  + ApiServlet.LADYBUG_API_PATH + "/testtool/views/.*$", observerRoles);
+		addConfigurationPart("PUT/"  + ApiServlet.LADYBUG_API_PATH + "/testtool/views/node-link-strategy$", observerRoles);
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/metadata/.*$", observerRoles);
 		addConfigurationPart("GET/"  + ApiServlet.LADYBUG_API_PATH + "/report/.*$", observerRoles);
 	}

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -210,19 +210,23 @@ public class TestToolApi extends ApiBase {
 				map.put("defaultView", false);
 			}
 			map.put("metadataNames", view.getMetadataNames());
-			map.put("nodeLinkStrategy", view.getNodeLinkStrategy());
+			if (getSessionAttr(view.getName() + ".NodeLinkStrategy", false) != null) {
+				map.put("nodeLinkStrategy", getSessionAttr(view.getName() + ".NodeLinkStrategy"));
+			} else {
+				map.put("nodeLinkStrategy", view.getNodeLinkStrategy());
+			}
 			response.put(view.getName(), map);
 		}
 		return Response.ok(response).build();
 	}
 
 	@PUT
-	@Path("/views/{nodeLinkStrategy}")
+	@Path("/views/node-link-strategy")
 	@Consumes(MediaType.APPLICATION_JSON)
-	public Response changeNodeLinkStrategy(@PathParam("nodeLinkStrategy") String nodeLinkStrategy, @QueryParam("viewName") String viewName) {
+	public Response changeNodeLinkStrategy(@QueryParam("nodeLinkStrategy") String nodeLinkStrategy, @QueryParam("viewName") String viewName) {
 		for (View view: views) {
 			if (viewName.equals(view.getName())) {
-				view.setNodeLinkStrategy(nodeLinkStrategy);
+				setSessionAttr(view.getName() + ".NodeLinkStrategy", nodeLinkStrategy);
 				break;
 			}
 		}

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -221,7 +221,7 @@ public class TestToolApi extends ApiBase {
 	}
 
 	@PUT
-	@Path("/views/node-link-strategy")
+	@Path("/node-link-strategy")
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response changeNodeLinkStrategy(@QueryParam("nodeLinkStrategy") String nodeLinkStrategy, @QueryParam("viewName") String viewName) {
 		for (View view: views) {

--- a/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
+++ b/src/main/java/nl/nn/testtool/web/api/TestToolApi.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2022 WeAreFrank!
+   Copyright 2021-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -208,9 +210,24 @@ public class TestToolApi extends ApiBase {
 				map.put("defaultView", false);
 			}
 			map.put("metadataNames", view.getMetadataNames());
+			map.put("nodeLinkStrategy", view.getNodeLinkStrategy());
 			response.put(view.getName(), map);
 		}
 		return Response.ok(response).build();
+	}
+
+	@PUT
+	@Path("/views/{nodeLinkStrategy}")
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response changeNodeLinkStrategy(@PathParam("nodeLinkStrategy") String nodeLinkStrategy, @QueryParam("viewName") String viewName) {
+		for (View view: views) {
+			if (viewName.equals(view.getName())) {
+				view.setNodeLinkStrategy(nodeLinkStrategy);
+				break;
+			}
+		}
+
+		return Response.ok().build();
 	}
 
 }


### PR DESCRIPTION
- The strategy of comparison in the compare tab is linked to the view.
- The default strategy of comparison for the PoM view is based on the checkpoint number.
- The default strategy of comparison for the other views is based on the path.