### PR TITLE
Feature: new utility class "DocumentUtil"

### DIFF
--- a/src/main/java/nl/nn/testtool/util/DocumentUtil.java
+++ b/src/main/java/nl/nn/testtool/util/DocumentUtil.java
@@ -1,2 +1,43 @@
-package nl.nn.testtool.util;public class DocumentUtil {
+/*
+   Copyright 2023 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+
+package nl.nn.testtool.util;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class DocumentUtil {
+
+    private static DocumentBuilder builder;
+
+
+    private static DocumentBuilderFactory newDocumentBuilderFactory() { return DocumentBuilderFactory.newInstance(); }
+
+    private static void setDocumentBuilder()  {
+        try {
+            if (builder == null) builder = newDocumentBuilderFactory().newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static DocumentBuilder getDocumentBuilder() {
+        setDocumentBuilder();
+        return builder;
+    }
 }

--- a/src/main/java/nl/nn/testtool/util/DocumentUtil.java
+++ b/src/main/java/nl/nn/testtool/util/DocumentUtil.java
@@ -1,0 +1,2 @@
+package nl.nn.testtool.util;public class DocumentUtil {
+}


### PR DESCRIPTION
- create new class 'DocumentUtil' to provide a reusable DocumentBuilder cleaner code

- Edit XmlUtil method 'stringToNode' to use the DocumentBuilder from DocumentUtil;
- Add new method 'getNodesByXpath' to find nodes within a provided XML or XSL Document using a provided XPath expression;
- Add new method 'fileHasNode' from future XSLT debugger functionality for reusability; Remove deprecated method;