### PR TITLE
Make LB views able to scope which reports are listed, not just which columns are shown

### DIFF
--- a/ladybug-common/src/main/java/org/wearefrank/ladybug/web/common/TestToolApiImpl.java
+++ b/ladybug-common/src/main/java/org/wearefrank/ladybug/web/common/TestToolApiImpl.java
@@ -172,6 +172,8 @@ public class TestToolApiImpl implements InitializingBean {
 			map.put("defaultView", view == views.getDefaultView());
 			map.put("metadataNames", view.getMetadataNames());
 			map.put("metadataLabels", view.getMetadataLabels());
+			// Expose the view's metadata filter so the frontend can apply it to the report list.
+			map.put("metadataFilter", view.getMetadataFilter());
 			map.put("crudStorage", view.getDebugStorage() instanceof CrudStorage);
 			map.put("nodeLinkStrategy", view.getNodeLinkStrategy());
 			map.put("hasCheckpointMatchers", view.hasCheckpointMatchers());

--- a/ladybug-frontend/src/app/shared/interfaces/view.ts
+++ b/ladybug-frontend/src/app/shared/interfaces/view.ts
@@ -7,4 +7,6 @@ export interface View {
   storageName: string;
   name: string;
   hasCheckpointMatchers: boolean;
+  // Optional per-view filter (metadataName -> value) applied to the report list.
+  metadataFilter?: Record<string, string>;
 }

--- a/ladybug-frontend/src/app/shared/services/http.service.ts
+++ b/ladybug-frontend/src/app/shared/services/http.service.ts
@@ -30,12 +30,27 @@ export class HttpService {
   }
 
   getMetadataReports(settings: TableSettings, view: View): Observable<Report[]> {
+    // Merge the view's metadataFilter beneath the user's column filters. A filter only applies to a
+    // column the backend selects, so filtered columns are added to metadataNames (the table still
+    // renders only view.metadataNames).
+    const filters = new Map<string, string>(settings.currentFilters);
+    const metadataNames = [...view.metadataNames];
+    if (view.metadataFilter) {
+      for (const [key, value] of Object.entries(view.metadataFilter)) {
+        if (!filters.has(key)) {
+          filters.set(key, value);
+        }
+        if (!metadataNames.includes(key)) {
+          metadataNames.push(key);
+        }
+      }
+    }
     return this.http.get<Report[]>(`api/metadata/${view.storageName}`, {
       params: {
         limit: settings.displayAmount,
-        filterHeader: [...settings.currentFilters.keys()],
-        filter: [...settings.currentFilters.values()],
-        metadataNames: view.metadataNames,
+        filterHeader: [...filters.keys()],
+        filter: [...filters.values()],
+        metadataNames: metadataNames,
       },
     });
   }


### PR DESCRIPTION
Today a Ladybug view changes the columns of the report list, but every view still shows the same set of reports. That makes a view a presentation choice rather than a way to focus on the reports that actually matter for a task.

This change lets a view carry its own filter, so selecting a view can narrow the list to just the reports relevant to it. A view becomes a purpose-built lens over a storage; for example, a view that surfaces only a particular category of reports, while leaving the underlying storage and all other views untouched. Users get there in one click instead of re-typing the same column filters every time.

The filter is treated as the view's baseline: any filtering a user types by hand still applies on top, so the view defines the starting point without taking control away from the user.

